### PR TITLE
Also require the order ID in the delivery message

### DIFF
--- a/rulebook.tex
+++ b/rulebook.tex
@@ -840,9 +840,10 @@ the MPS to immediately provide a base of the desired color.
 
 \noindent\textbf{DS}
 The DS prepare message denotes the slide the product should be delivered
-to. The DS will consume any workpiece provided, but points can only be
-scored if the DS was properly prepared before (means the corresponding
-delivery lane which was desired in the refbox order).
+to, as well as the order ID of the product that is delivered.  The DS
+will consume any workpiece provided, but points can only be scored if
+the DS was properly prepared before (means the corresponding delivery
+lane which was desired in the refbox order).
 
 \noindent\textbf{CS}
 The CS prepare message initiates either the retrieval or the mounting of

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -842,8 +842,8 @@ the MPS to immediately provide a base of the desired color.
 The DS prepare message denotes the slide the product should be delivered
 to, as well as the order ID of the product that is delivered.  The DS
 will consume any workpiece provided, but points can only be scored if
-the DS was properly prepared before (means the corresponding delivery
-lane which was desired in the refbox order).
+the DS has been properly prepared with the correct slide and order ID
+as requested by the refbox.
 
 \noindent\textbf{CS}
 The CS prepare message initiates either the retrieval or the mounting of


### PR DESCRIPTION
When delivering a product, the robot now also needs to send the ID of
the order that the product belongs to.

This idea was discussed at TC meeting 2/19.