### PR TITLE
Time limit and more zones/score for markerless machine recognition

### DIFF
--- a/rulebook.tex
+++ b/rulebook.tex
@@ -2009,13 +2009,14 @@ parts each, up to 10 for the explanation and methodologies, and up to
 10 for the public release of the source code.
 
 \vspace{-2ex}\paragraph{Recognition}
-The refbox will randomly select two zones and machine types. The
+The refbox will randomly select four zones and machine types. The
 machines are placed in the center of the respective zones. The robot
-must approach the machine one after another and use only sensors
+must approach the machines one after another and use only sensors
 mounted on the robot to recognize the physical type of the
-machine. The machines can be of any type.
+machine. The machines can be of any type. There is a time limit of
+\SI{2}{\minute} for the recognition task in which machines can be recognized.
 
-The recognition part scores up to 10 points --- 5 points for each
+The recognition part scores up to 20 points --- 5 points for each
 machine. Of these 5 points, 2 points are awarded for proper approach
 (robot standing at the input or output side of the machine facing
 towards the machine with a distance of no more than \SI{0.5}{\metre})


### PR DESCRIPTION
Introduce a timelimit in the markerless machine recoginition task, such that teams need to speed up their recognition algorithms. Also increased the number of available machines to 4 for faster teams.