### PR TITLE
Award 2 points for buffering a cap in the CS

### DIFF
--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1589,7 +1589,7 @@ inflicted on the machine or the referee needs longer to repair the
 machine the game continues and the machine will be offline for a
 longer time. Any production that was running will be aborted and any
 product which was being processed is no longer available and will be
-removed by the referee. Any additional bases delivered to the machine
+removed by the referee. Any additional bases or caps buffered at the machine
 will be void and the points gained removed. For storage stations, no
 slot is refilled, the load status remains exactly as before the broken
 state. The downtime is indicated by a flashing red light.
@@ -1704,6 +1704,8 @@ missing upon preparation will be subtracted later from points scored.
         Finish $C_3$ pre-cap & Mount the last ring of a $C_3$ product & $+80$
         \\
         Mount cap & Mount the cap on a product & $+10$
+        \\
+        Retrieve cap & Buffer a cap into a cap station & $+2$
         \\
         Retrieve from SS
         & A workpiece has been requested from storage and is ready for retrieval


### PR DESCRIPTION
Awarding 2 points for cap buffering at the CS.
The points will be deducted in case the machine gets broken or reset.