### PR TITLE
Add competitive orders

### DIFF
--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1640,11 +1640,11 @@ awarded. Performing a step for a later order which has not yet been
 announced cannot be awarded.
 
 For a competitive order, the same scoring scheme for in-time, delayed, and late
-delivery applies, with additional points for a successful first delivery
-and a point deduction for the second delivery (cf.~\reftab{tab:scoring}). The
-deduction may not exceed the points given for the delivery.\footnote{As an
-  example, if a team delivers late and scores only $5$ points for the delivery,
-only $5$ points will be deducted.} Points for production steps are given in the
+delivery applies, with additional points for a successful first delivery and a
+point deduction for the second delivery (cf.~\reftab{tab:scoring}). The
+deduction may not exceed the points given for the delivery\footnote{As an
+example, if a team delivers late and scores only $5$ points for the delivery,
+only $5$ points will be deducted.}. Points for production steps are given in the
 same way as for non-competitive orders. In particular, production points are
 also given if a team delivers the product after the other team.
 

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1737,6 +1737,16 @@ missing upon preparation will be subtracted later from points scored.
         \\
         False delivery & Deliver an intermediate product & $0$
         \\
+        1st competitive delivery
+        & Factor for delivering a product for a competitive order before the
+        other team
+        & $*2$
+        \\
+        2nd competitive delivery
+        & Factor for delivering a product for a competitive
+        order after the other team
+        & $*0$
+        \\
         Obstruction
         & Deliver a workpiece to a machine of the opposing team
         & $-20$

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1639,11 +1639,9 @@ belong to an upcoming (and announced) or on-going order can be
 awarded. Performing a step for a later order which has not yet been
 announced cannot be awarded.
 
-For a competitive order, the same scoring scheme for in-time, delayed,
-late, and wrong delivery applies, with an additional factor of $2$ if
-the team delivered before the other team, and a factor of $0$ if the
-team delivered after the other team (i.e., the second team does not get
-any points for the delivery).
+For a competitive order, the same scoring scheme for in-time, delayed, and late
+delivery applies for the first delivery, with an addition of $20$ points for a
+successful first delivery. For the second delivery, no points are given.
 
 There is a special case regarding the Storage Station. Retrieving a
 workpiece has a cost (see \reftab{tab:scoring}). The cost is
@@ -1745,14 +1743,13 @@ missing upon preparation will be subtracted later from points scored.
         False delivery & Deliver an intermediate product & $0$
         \\
         1st competitive delivery
-        & Factor for delivering a product for a competitive order before the
-        other team
-        & $*2$
+        & Points for the first delivery for a competitive order. The score is
+        given by the score for the regular delivery $+ 20$.
+        & up to $+ 40$
         \\
         2nd competitive delivery
-        & Factor for delivering a product for a competitive
-        order after the other team
-        & $*0$
+        & Second delivery of a final product for a competitive order.
+        & $0$
         \\
         Obstruction
         & Deliver a workpiece to a machine of the opposing team

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1512,26 +1512,27 @@ additional competitive order will be placed.\footnote{The numbers can
 be adjusted during the tournament by the Technical Committee, should
 this turn out to be necessary.}
 The complexities of orders will be similar for all games within a
-tournament phase. But the actual production chains are
-randomized. Each order will require one or more products of a
-specified product type to be delivered. The product is specified in
-terms of base color, rings (color and order), cap color, and possible
-delivery gate. The delivery time slot will have a randomized start
-time. The duration will be randomized between 30 to 180 seconds. The
-end time shall be within the game time. There is not necessarily an
-open order for a particular product at a specific time, or any order
-at all. The first order will be posted within the first 120 seconds of
-the game (but not necessarily at the beginning of the game). Orders
-for the products of complexity $C_2$ or $C_3$ will not begin in the
-first 300 seconds. An order will be announced before the delivery time
-slots starts. For $C_0$ products the lead time ahead of the start of
-the time window is 60 to 120 seconds, for $C_1$ it is 120 to 300
-seconds, and for $C_2$ and $C_3$ orders the time is between 300 and
-600 seconds. Two early orders will be posted that are announced in the
-first third of the game with a delivery time window in the last
-third. For each of the complexities $C_0$ and $C_1$ a standing order
-for a single product will be placed at the beginning of the production
-phase, which can be fulfilled at any time during the game.
+tournament phase. But the actual production chains are randomized.
+Each order will require one or more products of a specified product
+type to be delivered. A competitive order always requires exactly one
+product to be delivered. The product is specified in terms of base
+color, rings (color and order), cap color, and possible delivery gate.
+The delivery time slot will have a randomized start time. The duration
+will be randomized between 30 to 180 seconds. The end time shall be
+within the game time. There is not necessarily an open order for a
+particular product at a specific time, or any order at all. The first
+order will be posted within the first 120 seconds of the game (but not
+necessarily at the beginning of the game). Orders for the products of
+complexity $C_2$ or $C_3$ will not begin in the first 300 seconds. An
+order will be announced before the delivery time slots starts. For
+$C_0$ products the lead time ahead of the start of the time window is
+60 to 120 seconds, for $C_1$ it is 120 to 300 seconds, and for $C_2$
+and $C_3$ orders the time is between 300 and 600 seconds. Two early
+orders will be posted that are announced in the first third of the
+game with a delivery time window in the last third. For each of the
+complexities $C_0$ and $C_1$ a standing order for a single product
+will be placed at the beginning of the production phase, which can be
+fulfilled at any time during the game.
 
 Teams playing on the field at the same time will get the same
 production plan. However, each game will use a new randomized order

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1498,13 +1498,11 @@ refbox. There will be one color requiring 2 additional bases, one
 requiring 1 base, and two colors requiring no additional base at
 all. Products retrieved from the Storage Station may be used only for
 $C_0$ orders with a requested quantity equal to or greater than two.
-An order can be \emph{competitive} or \emph{non-competitive}. For a
-competitive order, only the team that delivers first will score points
-for the delivery, and it will score higher
-(cf.~\reftab{tab:scoring-production}). The other team will still get points for
-production steps, but it will not get any points for the delivery, even if it
-delivers in time. For a non-competitive order, each team can score independently
-of the other team.
+An order can be \emph{competitive} or \emph{non-competitive}. For a competitive
+order, the scoring differs between first and second delivery; the team that
+delivers first will get more points than the other team
+(cf.~\refsec{sec:production-scoring}). For a non-competitive order, each team
+scores independently of the other team.
 
 In each game, up to 9 orders will be placed within the regular game.
 1 of those orders will be \emph{competitive}, while the remaining

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1506,7 +1506,7 @@ in time. For a non-competitive order, each team can score independently of the
 other team.
 
 In each game, up to 9 orders will be placed within the regular game.
-4 of those 9 orders will be \emph{competitive}, while the remaining
+1 of those orders will be \emph{competitive}, while the remaining
 orders will be \emph{non-competitive}. In case of overtime, an
 additional competitive order will be placed.\footnote{The numbers can
 be adjusted during the tournament by the Technical Committee, should

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1502,8 +1502,8 @@ An order can be \emph{competitive} or \emph{non-competitive}. For a
 competitive order, only the team that delivers first will score points
 for the delivery, and it will score twice the amount of points. The
 other team will not get any points for the delivery, even if it delivers
-in time.  For a non-competitive order, both teams score on delivery with
-a factor of $1$.
+in time. For a non-competitive order, each team can score independently of the
+other team.
 
 In each game, up to 9 orders will be placed within the regular game.
 4 of those 9 orders will be \emph{competitive}, while the remaining

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1638,6 +1638,12 @@ belong to an upcoming (and announced) or on-going order can be
 awarded. Performing a step for a later order which has not yet been
 announced cannot be awarded.
 
+For a competitive order, the same scoring scheme for in-time, delayed,
+late, and wrong delivery applies, with an additional factor of $2$ if
+the team delivered before the other team, and a factor of $0$ if the
+team delivered after the other team (i.e., the second team does not get
+any points for the delivery).
+
 There is a special case regarding the Storage Station. Retrieving a
 workpiece has a cost (see \reftab{tab:scoring}). The cost is
 subtracted as soon as the workpiece is ready for retrieval on the SS\@.

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1501,9 +1501,10 @@ $C_0$ orders with a requested quantity equal to or greater than two.
 An order can be \emph{competitive} or \emph{non-competitive}. For a
 competitive order, only the team that delivers first will score points
 for the delivery, and it will score higher
-(cf.~\reftab{tab:scoring-production}). The other team will not get any points
-for the delivery, even if it delivers in time. For a non-competitive order, each
-team can score independently of the other team.
+(cf.~\reftab{tab:scoring-production}). The other team will still get points for
+production steps, but it will not get any points for the delivery, even if it
+delivers in time. For a non-competitive order, each team can score independently
+of the other team.
 
 In each game, up to 9 orders will be placed within the regular game.
 1 of those orders will be \emph{competitive}, while the remaining

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1640,11 +1640,11 @@ awarded. Performing a step for a later order which has not yet been
 announced cannot be awarded.
 
 For a competitive order, the same scoring scheme for in-time, delayed, and late
-delivery applies for the first delivery, with additional points for a successful
-first delivery (cf.~\reftab{tab:scoring}). For the second delivery, no delivery
-points are given. Points for production steps are given in the same way as for
-non-competitive orders. In particular, production points are also given if a
-team delivers the product after the other team.
+delivery applies, with additional points for a successful first delivery
+and a point deduction for the second delivery (cf.~\reftab{tab:scoring}). Points
+for production steps are given in the same way as for non-competitive orders. In
+particular, production points are also given if a team delivers the product
+after the other team.
 
 There is a special case regarding the Storage Station. Retrieving a
 workpiece has a cost (see \reftab{tab:scoring}). The cost is
@@ -1747,12 +1747,13 @@ missing upon preparation will be subtracted later from points scored.
         \\
         1st competitive delivery
         & Points for the first delivery for a competitive order. The score is
-        given by the score for the regular delivery $+ 10$.
-        & up to $+ 30$
+        given in addition to the points for the regular delivery.
+        &$+ 10$
         \\
         2nd competitive delivery
-        & Second delivery of a final product for a competitive order.
-        & $0$
+        & Point deduction for the second delivery for a competitive order. The
+        points are deducted from the delivery points.
+        &$- 10$
         \\
         Obstruction
         & Deliver a workpiece to a machine of the opposing team

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1500,10 +1500,10 @@ all. Products retrieved from the Storage Station may be used only for
 $C_0$ orders with a requested quantity equal to or greater than two.
 An order can be \emph{competitive} or \emph{non-competitive}. For a
 competitive order, only the team that delivers first will score points
-for the delivery, and it will score twice the amount of points. The
-other team will not get any points for the delivery, even if it delivers
-in time. For a non-competitive order, each team can score independently of the
-other team.
+for the delivery, and it will score higher
+(cf.~\reftab{tab:scoring-production}). The other team will not get any points
+for the delivery, even if it delivers in time. For a non-competitive order, each
+team can score independently of the other team.
 
 In each game, up to 9 orders will be placed within the regular game.
 1 of those orders will be \emph{competitive}, while the remaining

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1498,11 +1498,19 @@ refbox. There will be one color requiring 2 additional bases, one
 requiring 1 base, and two colors requiring no additional base at
 all. Products retrieved from the Storage Station may be used only for
 $C_0$ orders with a requested quantity equal to or greater than two.
+An order can be \emph{competitive} or \emph{non-competitive}. For a
+competitive order, only the team that delivers first will score points
+for the delivery, and it will score twice the amount of points. The
+other team will not get any points for the delivery, even if it delivers
+in time.  For a non-competitive order, both teams score on delivery with
+a factor of $1$.
 
-In each game, up to 10 orders will be placed.\footnote{There will up
-  to 9 orders in regular game time, and an additional order in the
-  case of overtime. The number can be adjusted during the tournament
-  by the Technical Committee, should this turn out to be necessary.}
+In each game, up to 9 orders will be placed within the regular game.
+4 of those 9 orders will be \emph{competitive}, while the remaining
+orders will be \emph{non-competitive}. In case of overtime, an
+additional competitive order will be placed.\footnote{The numbers can
+be adjusted during the tournament by the Technical Committee, should
+this turn out to be necessary.}
 The complexities of orders will be similar for all games within a
 tournament phase. But the actual production chains are
 randomized. Each order will require one or more products of a

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1642,8 +1642,10 @@ announced cannot be awarded.
 
 For a competitive order, the same scoring scheme for in-time, delayed, and late
 delivery applies for the first delivery, with additional points for a successful
-first delivery (cf.~\reftab{tab:scoring}). For the second delivery, no points
-are given.
+first delivery (cf.~\reftab{tab:scoring}). For the second delivery, no delivery
+points are given. Points for production steps are given in the same way as for
+non-competitive orders. In particular, production points are also given if a
+team delivers the product after the other team.
 
 There is a special case regarding the Storage Station. Retrieving a
 workpiece has a cost (see \reftab{tab:scoring}). The cost is

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1640,7 +1640,7 @@ awarded. Performing a step for a later order which has not yet been
 announced cannot be awarded.
 
 For a competitive order, the same scoring scheme for in-time, delayed, and late
-delivery applies for the first delivery, with an addition of $20$ points for a
+delivery applies for the first delivery, with an addition of $10$ points for a
 successful first delivery. For the second delivery, no points are given.
 
 There is a special case regarding the Storage Station. Retrieving a
@@ -1744,8 +1744,8 @@ missing upon preparation will be subtracted later from points scored.
         \\
         1st competitive delivery
         & Points for the first delivery for a competitive order. The score is
-        given by the score for the regular delivery $+ 20$.
-        & up to $+ 40$
+        given by the score for the regular delivery $+ 10$.
+        & up to $+ 30$
         \\
         2nd competitive delivery
         & Second delivery of a final product for a competitive order.

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1531,7 +1531,8 @@ orders will be posted that are announced in the first third of the
 game with a delivery time window in the last third. For each of the
 complexities $C_0$ and $C_1$ a standing order for a single product
 will be placed at the beginning of the production phase, which can be
-fulfilled at any time during the game.
+fulfilled at any time during the game. Competitive orders are always for
+products of complexity $C_0$. A competitive order cannot be a standing order.
 
 Teams playing on the field at the same time will get the same
 production plan. However, each game will use a new randomized order

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1641,10 +1641,12 @@ announced cannot be awarded.
 
 For a competitive order, the same scoring scheme for in-time, delayed, and late
 delivery applies, with additional points for a successful first delivery
-and a point deduction for the second delivery (cf.~\reftab{tab:scoring}). Points
-for production steps are given in the same way as for non-competitive orders. In
-particular, production points are also given if a team delivers the product
-after the other team.
+and a point deduction for the second delivery (cf.~\reftab{tab:scoring}). The
+deduction may not exceed the points given for the delivery.\footnote{As an
+  example, if a team delivers late and scores only $5$ points for the delivery,
+only $5$ points will be deducted.} Points for production steps are given in the
+same way as for non-competitive orders. In particular, production points are
+also given if a team delivers the product after the other team.
 
 There is a special case regarding the Storage Station. Retrieving a
 workpiece has a cost (see \reftab{tab:scoring}). The cost is

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1754,7 +1754,8 @@ missing upon preparation will be subtracted later from points scored.
         \\
         2nd competitive delivery
         & Point deduction for the second delivery for a competitive order. The
-        points are deducted from the delivery points.
+        points are deducted from the delivery points, the total cannot be less
+        than 0 points.
         &$- 10$
         \\
         Obstruction

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1641,8 +1641,9 @@ awarded. Performing a step for a later order which has not yet been
 announced cannot be awarded.
 
 For a competitive order, the same scoring scheme for in-time, delayed, and late
-delivery applies for the first delivery, with an addition of $10$ points for a
-successful first delivery. For the second delivery, no points are given.
+delivery applies for the first delivery, with additional points for a successful
+first delivery (cf.~\reftab{tab:scoring}). For the second delivery, no points
+are given.
 
 There is a special case regarding the Storage Station. Retrieving a
 workpiece has a cost (see \reftab{tab:scoring}). The cost is


### PR DESCRIPTION
For a competitive order, only the team that delivers first gets points for the delivery, the second team will not get any points.

Points for production steps are unaffected.

This resolves #4.