### PR TITLE
Add latex linter, filetype, and max linewidth checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,3 +10,17 @@ jobs:
           command: latexmk -pdf rulebook.tex
       - store_artifacts:
           path: rulebook.pdf
+  check:
+    docker:
+      - image: danteev/texlive:TL2017
+    steps:
+      - checkout
+      - run:
+          name: Run all checks
+          command: make check
+workflows:
+  version: 2
+  build_and_check:
+    jobs:
+      - build
+      - check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: danteev/texlive:TL2017
+      - image: morxa/fedora-texlive
     steps:
       - checkout
       - run:
@@ -12,7 +12,7 @@ jobs:
           path: rulebook.pdf
   check:
     docker:
-      - image: danteev/texlive:TL2017
+      - image: morxa/fedora-texlive
     steps:
       - checkout
       - run:

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,12 @@ pdf:
 check: lint check-filetype check-trailing-whitespace
 
 lint:
-	@lacheck rulebook.tex | tee lacheck.log
-	@bash -c 'if [ -s lacheck.log ] ; then exit 1 ; fi'
+	@chktex rulebook.tex | tee chktex.log
+	@bash -c '\
+		if [ -s chktex.log ] ; then \
+			echo "ERROR(lint): chktex found errors"; \
+			exit 1; \
+		fi'
 
 check-filetype:
 	@bash -c '\

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 pdf:
 	latexmk -pdf rulebook.tex
 
-check: lint check-filetype check-trailing-whitespace
+check: lint check-filetype check-trailing-whitespace check-line-length
 
 # warning numbers that chktex should ignore
 chktex_ignore=24 44
+
+# maximum allowed length of a line
+linelength=80
 
 lint:
 	@chktex -q $(foreach w,$(chktex_ignore),-n $w) rulebook.tex | tee chktex.log
@@ -30,5 +33,14 @@ check-trailing-whitespace:
 		if [ $$? -eq 0 ] ; then \
 			echo "Found trailing whitespace:"; \
 			echo "$$trailing"; \
+			exit 1; \
+		fi'
+
+check-line-length:
+	@bash -c '\
+		longlines=$$(grep -n "^..\{${linelength}\}" rulebook.tex); \
+		if [ $$? -eq 0 ] ; then \
+			echo "ERROR: Found lines exceeding the line length ${linelength}:"; \
+			echo "$$longlines"; \
 			exit 1; \
 		fi'

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,11 @@ pdf:
 
 check: lint check-filetype check-trailing-whitespace
 
+# warning numbers that chktex should ignore
+chktex_ignore=24 44
+
 lint:
-	@chktex rulebook.tex | tee chktex.log
+	@chktex -q $(foreach w,$(chktex_ignore),-n $w) rulebook.tex | tee chktex.log
 	@bash -c '\
 		if [ -s chktex.log ] ; then \
 			echo "ERROR(lint): chktex found errors"; \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+pdf:
+	latexmk -pdf rulebook.tex
+
+check: lint check-filetype check-trailing-whitespace
+
+lint:
+	@lacheck rulebook.tex | tee lacheck.log
+	@bash -c 'if [ -s lacheck.log ] ; then exit 1 ; fi'
+
+check-filetype:
+	@bash -c '\
+		expected="LaTeX 2e document, UTF-8 Unicode text"; \
+		actual="$$(file -b rulebook.tex)"; \
+		if [ "$$actual" != "$$expected" ] ; then \
+			echo "Unexpected filetype"; \
+			echo "Expected: $$expected"; \
+			echo "Actual: $$actual"; \
+		fi'
+
+check-trailing-whitespace:
+	@bash -c '\
+		trailing=$$(grep -n "\s$$" rulebook.tex); \
+		if [ $$? -eq 0 ] ; then \
+			echo "Found trailing whitespace:"; \
+			echo "$$trailing"; \
+			exit 1; \
+		fi'

--- a/Makefile
+++ b/Makefile
@@ -22,17 +22,19 @@ check-filetype:
 		expected="LaTeX 2e document, UTF-8 Unicode text"; \
 		actual="$$(file -b rulebook.tex)"; \
 		if [ "$$actual" != "$$expected" ] ; then \
-			echo "Unexpected filetype"; \
+			echo "ERROR: Unexpected filetype"; \
 			echo "Expected: $$expected"; \
 			echo "Actual: $$actual"; \
+			exit 1; \
 		fi'
 
 check-trailing-whitespace:
 	@bash -c '\
 		trailing=$$(grep -n "\s$$" rulebook.tex); \
 		if [ $$? -eq 0 ] ; then \
-			echo "Found trailing whitespace:"; \
+			echo "Lines with trailing whitespace:"; \
 			echo "$$trailing"; \
+		  echo "ERROR: Found trailing whitespace"; \
 			exit 1; \
 		fi'
 
@@ -40,7 +42,8 @@ check-line-length:
 	@bash -c '\
 		longlines=$$(grep -n "^..\{${linelength}\}" rulebook.tex); \
 		if [ $$? -eq 0 ] ; then \
-			echo "ERROR: Found lines exceeding the line length ${linelength}:"; \
+			echo "Lines with length > ${linelength}:"; \
 			echo "$$longlines"; \
+			echo "ERROR: Found lines exceeding the max line length ${linelength}:"; \
 			exit 1; \
 		fi'

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -10,7 +10,6 @@
 
 \setlength{\marginparwidth}{1cm}
 %\usepackage{fourier}
-%\newcommand\rulechange[1]{\begin{shaded}#1\end{shaded}\marginpar{\LARGE\danger}}
 
 \usepackage{wrapfig}
 \usepackage{fnpct}
@@ -37,7 +36,9 @@
 \newcolumntype{C}{>{\centering\arraybackslash}X}
 
 \newsavebox{\myt}
-\newcommand{\mytable}[1]{\savebox{\myt}{#1}\tikz\node[fill=gray!25!white]{\usebox{\myt}};}
+\newcommand{\mytable}[1]{%
+  \savebox{\myt}{#1}\tikz\node[fill=gray!25!white]{\usebox{\myt}};%
+}
 
 \newcommand{\refsec}[1]{Section~\ref{#1}}
 \newcommand{\reffig}[1]{Figure~\ref{#1}}
@@ -155,7 +156,9 @@
       Gerald Steinbauer&Tobias Neumann\\
     \end{tabular}
     \vfill
-    Revision Date: Thursday, January 25\textsuperscript{\raisebox{-.2ex}{th}} 2018 %DRAFT -- Work in Progress
+    Revision Date: Thursday, January 25\textsuperscript{\raisebox{-.2ex}{th}}
+    2018
+    %DRAFT -- Work in Progress
   \end{center}
 \end{titlepage}
 \thispagestyle{empty}
@@ -332,7 +335,8 @@ advancements. Current members of the TC are (in alphabetical order):\\[.5em]
 \emph{Vincent Coelen}, Ecole polytechnique universitaire de Lille\\
 \emph{Christian Deppe}, Festo Didactic SE, Denkendorf, Germany\\
 \emph{Till Hoffmann}, RWTH Aachen University, Aachen, Germany\\
-\emph{Alain Rohr}, HFTM Technical Institute of Applied Science Mittelland, Biel, Switzerland\\
+\emph{Alain Rohr}, HFTM Technical Institute of Applied Science Mittelland,
+Biel, Switzerland\\
 To get into contact with the TC use the mailing list\\
 \centerline{\url{robocup-logistics-tc@lists.kbsg.rwth-aachen.de}}
 
@@ -343,7 +347,8 @@ RoboCup competitions, to communicate to the RoboCup Federation
 trustees and chairs the requirements of the league, and to inform and
 attract new teams to the league. Current members of the OC are (in
 alphabetical order):\\[.5em]
-\emph{Stefan Brandenberger}, HFTM Technical Institute of Applied Science Mittelland, Biel, Switzerland\\
+\emph{Stefan Brandenberger}, HFTM Technical Institute of Applied Science
+Mittelland, Biel, Switzerland\\
 \emph{Christian Deppe}, Festo Didactic SE, Denkendorf, Germany\\
 \emph{Florian Eith}, Friedrich-Alexander University, Erlangen, Germany\\
 \emph{Ulrich Karras}, priv. Dozent, Essen, Germany\\
@@ -382,7 +387,7 @@ league is available at\\
 \subsection{Field Layout and Dimensions}
 \label{sec:competition-area}
 \begin{figure}[p]
-    \includegraphics[width=\paperwidth, angle=-90, trim = 0 0 0 0,]{field2017.pdf}
+    \includegraphics[width=\paperwidth, angle=-90, trim=0 0 0 0,]{field2017.pdf}
     \vspace{1ex}
     \caption{Competition area: squares indicate zones for possible
       machine placements, circles denote robots. Cyan and magenta are
@@ -481,11 +486,11 @@ height.\footnote{Note however, that due to small variances and
   working height of some or all parts of a station.} Working space
 between guiding lanes is \SI{4.5}{\centi\metre}. Setup lanes and
 shelves feature approximately the same space for handling and
-adjusting. All diffuse sensors (input side) have been removed to allow for infrared-emitting cameras.
-To simplify the delivery on the belt, each machine will be
-equipped with a narrowing cone on its input side (\reffig{fig:narrow-cone}).
-You can order them from Festo Didactic SE (C. Deppe)
-or download the STL model file from the RCLL site.
+adjusting. All diffuse sensors (input side) have been removed to allow
+for infrared-emitting cameras.  To simplify the delivery on the belt,
+each machine will be equipped with a narrowing cone on its input side
+(\reffig{fig:narrow-cone}).  You can order them from Festo Didactic SE
+(C. Deppe) or download the STL model file from the RCLL site.
 \begin{figure}
     \includegraphics[height=8cm]{narrowConeSketch.jpg}
 \caption{Narrowing cone}
@@ -526,10 +531,11 @@ Based on these shared properties, there are five kinds of machines:
   anew for each game) to add base elements. There are two RS per team.
 
 \item[Storage Station (SS)] provides 24 slots of storage divided into
-  6 layers (\reffig{fig:SS_portrait}). For now items can be  shipped out on the output side on
-  request. The Storage Station provides a sample of each possible
-  $C_0$ configuration (one per layer).\footnote{Note that this is the
-    specific content for 2018 and may change in the future.}
+  6 layers (\reffig{fig:SS_portrait}). For now items can be  shipped
+  out on the output side on request. The Storage Station provides a
+  sample of each possible $C_0$ configuration (one per
+  layer).\footnote{Note that this is the specific content for 2018 and
+  may change in the future.}
 
 \item[Delivery Station (DS)] Accepts completed products. The stations
   contains three slides (\reffig{fig:DS}). The robot has to prepare
@@ -624,17 +630,65 @@ phase. Processing times are outlined in \reftab{tab:processing-times}.
   \centering
   \begin{tabular}{|l|c|c|c|c|l|}
     \hline
-    && \multicolumn{2}{c|}{Input} & \multicolumn{2}{c|}{Output}\\\hline
-    &Machine & ID & Tag & ID & Tag\\\hline
+    && \multicolumn{2}{c|}{Input}
+    & \multicolumn{2}{c|}{Output}
+    \\
+    \hline
+    &Machine & ID & Tag & ID & Tag
+    \\
+    \hline
     &&&&&\\[-2ex]
-    \multirow{7}{*}{\rotatebox{90}{\bfseries Cyan\hspace{3.75cm}}}&
-    CS 1&1&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_1}}&2&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_2}}\\[2.5ex]
-    &CS 2&17&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_17}}&18&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_18}}\\[2.5ex]
-    &RS 1&33&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_33}}&34&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_34}}\\[2.5ex]
-    &RS 2&177&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_177}}&178&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_178}}\\[2.5ex]
-    &BS&65&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_65}}&66&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_66}}\\[2.5ex]
-    &DS&81&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_81}}&82&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_82}}\\[2.5ex]
-    &SS&193&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_193}}&194&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_194}}\\[2.5ex]\hline
+    \multirow{7}{*}{\rotatebox{90}{\bfseries Cyan\hspace{3.75cm}}}
+    & CS 1 & 1
+           & \parbox[c]{1.2cm}{
+               \includegraphics[width=1.2cm]{markers/figure_1}}
+           & 2
+           & \parbox[c]{1.2cm}{
+               \includegraphics[width=1.2cm]{markers/figure_2}}
+    \\[2.5ex]
+    & CS 2 & 17
+           & \parbox[c]{1.2cm}{
+               \includegraphics[width=1.2cm]{markers/figure_17}}
+           & 18
+           & \parbox[c]{1.2cm}{
+               \includegraphics[width=1.2cm]{markers/figure_18}}
+    \\[2.5ex]
+    & RS 1 & 33
+           & \parbox[c]{1.2cm}{
+               \includegraphics[width=1.2cm]{markers/figure_33}}
+           & 34
+           & \parbox[c]{1.2cm}{
+               \includegraphics[width=1.2cm]{markers/figure_34}}
+    \\[2.5ex]
+    & RS 2 & 177
+           & \parbox[c]{1.2cm}{
+               \includegraphics[width=1.2cm]{markers/figure_177}}
+           & 178
+           & \parbox[c]{1.2cm}{
+               \includegraphics[width=1.2cm]{markers/figure_178}}
+    \\[2.5ex]
+    & BS & 65
+         & \parbox[c]{1.2cm}{
+             \includegraphics[width=1.2cm]{markers/figure_65}}
+         & 66
+         & \parbox[c]{1.2cm}{
+             \includegraphics[width=1.2cm]{markers/figure_66}}
+    \\[2.5ex]
+    & DS & 81
+         & \parbox[c]{1.2cm}{
+             \includegraphics[width=1.2cm]{markers/figure_81}}
+         & 82
+         & \parbox[c]{1.2cm}{
+             \includegraphics[width=1.2cm]{markers/figure_82}}
+    \\[2.5ex]
+    & SS & 193
+         & \parbox[c]{1.2cm}{
+             \includegraphics[width=1.2cm]{markers/figure_193}}
+         & 194
+         & \parbox[c]{1.2cm}{
+             \includegraphics[width=1.2cm]{markers/figure_194}}
+    \\[2.5ex]
+    \hline
   \end{tabular}
   \hfill
   \begin{tabular}{|l|c|c|c|c|c|}
@@ -642,13 +696,57 @@ phase. Processing times are outlined in \reftab{tab:processing-times}.
     && \multicolumn{2}{c|}{Input} & \multicolumn{2}{c|}{Output}\\\hline
     &Machine & ID & Tag & ID & Tag\\\hline
     &&&&&\\[-2ex]
-    \multirow{7}{*}{\rotatebox{90}{\bfseries Magenta\hspace{3.4cm}}}&CS 1&97&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_97}}&98&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_98}}\\[2.5ex]
-    &CS 2&113&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_113}}&114&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_114}}\\[2.5ex]
-    &RS 1&129&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_129}}&130&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_130}}\\[2.5ex]
-    &RS 2&145&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_145}}&146&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_146}}\\[2.5ex]
-    &BS&161&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_161}}&162&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_162}}\\[2.5ex]
-    &DS&49&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_49}}&50&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_50}}\\[2.5ex]
-    &SS&209&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_209}}&210&\parbox[c]{1.2cm}{\includegraphics[width=1.2cm]{markers/figure_210}}\\[2.5ex]\hline
+    \multirow{7}{*}{ \rotatebox{90}{\bfseries Magenta\hspace{3.4cm}}}
+    & CS 1 & 97
+           & \parbox[c]{1.2cm}{
+               \includegraphics[width=1.2cm]{markers/figure_97}}
+           & 98
+           & \parbox[c]{1.2cm}{
+               \includegraphics[width=1.2cm]{markers/figure_98}}
+    \\[2.5ex]
+    & CS 2 & 113
+           & \parbox[c]{1.2cm}{
+               \includegraphics[width=1.2cm]{markers/figure_113}}
+           & 114
+           & \parbox[c]{1.2cm}{
+               \includegraphics[width=1.2cm]{markers/figure_114}}
+    \\[2.5ex]
+    & RS 1 & 129
+           & \parbox[c]{1.2cm}{
+               \includegraphics[width=1.2cm]{markers/figure_129}}
+           & 130
+           & \parbox[c]{1.2cm}{
+               \includegraphics[width=1.2cm]{markers/figure_130}}
+    \\[2.5ex]
+    & RS 2 & 145
+           & \parbox[c]{1.2cm}{
+               \includegraphics[width=1.2cm]{markers/figure_145}}
+           & 146
+           & \parbox[c]{1.2cm}{
+               \includegraphics[width=1.2cm]{markers/figure_146}}
+    \\[2.5ex]
+    & BS & 161
+         & \parbox[c]{1.2cm}{
+             \includegraphics[width=1.2cm]{markers/figure_161}}
+         & 162
+         & \parbox[c]{1.2cm}{
+             \includegraphics[width=1.2cm]{markers/figure_162}}
+    \\[2.5ex]
+    & DS & 49
+         & \parbox[c]{1.2cm}{
+             \includegraphics[width=1.2cm]{markers/figure_49}}
+         & 50
+         & \parbox[c]{1.2cm}{
+              \includegraphics[width=1.2cm]{markers/figure_50}}
+    \\[2.5ex]
+    & SS & 209
+         & \parbox[c]{1.2cm}{
+             \includegraphics[width=1.2cm]{markers/figure_209}}
+         & 210
+         & \parbox[c]{1.2cm}{
+             \includegraphics[width=1.2cm]{markers/figure_210}}
+    \\[2.5ex]
+    \hline
   \end{tabular}
   \caption{Machine tags are ALVAR tags with the given IDs.}
   \label{tab:markers}
@@ -667,12 +765,17 @@ printing on the RoboCup Logistics website.
 \subsubsection{Machine Positioning}
 \label{sec:machine-swapping}
 The zones and rotations for the MPS will be randomly chosen by the RefBox.
-Each game will have a new randomly generated field layout, the referees will place the MPS in the middle of the zone with given rotation at there best effort but errors of the positioning should be expected.
+Each game will have a new randomly generated field layout, the referees will
+place the MPS in the middle of the zone with given rotation at there best effort
+but errors of the positioning should be expected.
 
 \begin{wrapfigure}[14]{r}{0.2\linewidth}
   \centering
   \vspace{-2.1ex}
-  \mytable{\begin{tabularx}{\linewidth}{>{\raggedleft\arraybackslash}X|>{\raggedleft\arraybackslash}X}
+  \mytable{
+    \begin{tabularx}{\linewidth}{
+      >{\raggedleft\arraybackslash}X|>{\raggedleft\arraybackslash}X
+    }
       Cyan & Magenta \\ \hline
       \ang{0}&\ang{180}\\
       \ang{45}&\ang{135}\\
@@ -702,39 +805,48 @@ aligned with the field (in terms of orientation). Furthermore, an MPS
 at an orientation of \ang{90} will be rotated counter-clockwise a
 quarter turn compared to the field system.
 
-To ensure fairness, positions and orientations of the machines are
-mirrored along the field's y-axis. There are two cases that need to be
-handled separately. First, machines in a cell not adjacent to the
-wall, and machines of types BS, DS, and SS (even when adjacent to the wall) are mirrored according to
-\reftab{tab:mirror-a}. Second, CS and RS stations must be handled
-slightly different, if oriented next to a wall (zones: C-Z*1, C-Z*8,
-C-Z7*, M-Z*1, M-Z*8 and M-Z7*). The reason being, that the shelf and
-slide of these stations are offset sideways at the input side. This
-might lead to the situation that for one team the shelf is close to
-the wall, and for the other it is not. To remedy this problem, the RS
-and CS machines adjacent to a wall will always be placed such that the
-shelf or slide is on the farther end with respect to the wall. For
-example, in \reffig{fig:competition-area}, the magenta CS in M-Z76
-with a rotation of \ang{270}. Were this setup mirrored, the shelf on the cyan CS in
-C-Z76 would be close to the wall. Instead, it has a different
-orientation violating the y-symmetry but allowing for easier access to
-the shelf.
+To ensure fairness, positions and orientations of the machines are mirrored
+along the field's y-axis. There are two cases that need to be handled
+separately. First, machines in a cell not adjacent to the wall, and machines of
+types BS, DS, and SS (even when adjacent to the wall) are mirrored according to
+\reftab{tab:mirror-a}. Second, CS and RS stations must be handled slightly
+different, if oriented next to a wall (zones: C-Z*1, C-Z*8, C-Z7*, M-Z*1, M-Z*8
+and M-Z7*). The reason being, that the shelf and slide of these stations are
+offset sideways at the input side. This might lead to the situation that for one
+team the shelf is close to the wall, and for the other it is not. To remedy this
+problem, the RS and CS machines adjacent to a wall will always be placed such
+that the shelf or slide is on the farther end with respect to the wall. For
+example, in \reffig{fig:competition-area}, the magenta CS in M-Z76 with a
+rotation of \ang{270}. Were this setup mirrored, the shelf on the cyan CS in
+C-Z76 would be close to the wall. Instead, it has a different orientation
+violating the y-symmetry but allowing for easier access to the shelf.
 
 \begin{figure}[t!]
     \centering
-    \subfigure[For rotations with \ang{0}, \ang{90}, \ang{180} or \ang{270}. BS, CS, and RS block the zones close to the input as well as the output. DS and SS block the zones close to the input respectively the output.]{
+    \subfigure[
+      For rotations with \ang{0}, \ang{90}, \ang{180} or \ang{270}. BS, CS, and
+      RS block the zones close to the input as well as the output. DS and SS
+      block the zones close to the input respectively the output.
+    ]{
         \label{fig:zone-mps-rotation-straight}%
         \centering
         \includegraphics[width=\textwidth]{bZones1.pdf}
     }
     \quad
-    \subfigure[For rotations with  \ang{45}, \ang{135}, \ang{225} and \ang{315}. BS, CS, and RS block the zones close to the input as well as the output. DS and SS block the zones close to the input respectively the output.]{
+    \subfigure[
+      For rotations with  \ang{45}, \ang{135}, \ang{225} and \ang{315}. BS, CS,
+      and RS block the zones close to the input as well as the output. DS and SS
+      block the zones close to the input respectively the output.
+    ]{
         \label{fig:zone-mps-rotation-odd}
         \centering
         \includegraphics[width=\textwidth]{bZones2.pdf}
     }
-    \caption{Blocked zones regarding the MPS rotation (red zones must
-      not be used as position for other machines and must be located inside the competition area).}
+    \caption{
+      Blocked zones regarding the MPS rotation (red zones must not be used as
+      position for other machines and must be located inside the competition
+      area).
+    }
     \label{fig:zone-mps-blocked}
 \end{figure}
 For placing of machines, the RefBox will take care of the necessary
@@ -744,11 +856,11 @@ slides are reachable.  If a machine is rotated with \ang{0}, \ang{90},
 are blocked as well (\reffig{fig:zone-mps-rotation-straight}).  For
 machines with rotations \ang{45}, \ang{135}, \ang{225} and \ang{315}
 three zones in front of each input and output side are blocked
-(\reffig{fig:zone-mps-rotation-odd}). No MPS nor blocked zones for another MPS may be placed in a
-blocked zone. All blocked zones of any MPS must be located within the
-competition area. Furthermore, only two machines will ever be placed
-next to each other, a third machine will only be placed with at least
-one empty zone in-between.
+(\reffig{fig:zone-mps-rotation-odd}). No MPS nor blocked zones for another MPS
+may be placed in a blocked zone. All blocked zones of any MPS must be located
+within the competition area. Furthermore, only two machines will ever be placed
+next to each other, a third machine will only be placed with at least one empty
+zone in-between.
 
 The MPS will be placed mostly on the primary half of a team
 (cf. \refsec{sec:competition-area}). However, some machines will be
@@ -773,22 +885,31 @@ located and in which rotations they are positioned.
 The Referee Box assigns each machine to a team and a zone
 (\reffig{fig:competition-area}) at the start of the exploration
 phase,\footnote{Since 2017 there are no more fixed stations.}
-The zones and orientations (in steps of 45$^\circ$) are randomly determined,  and will not be
-communicated until the production phase. For details about the
+The zones and orientations (in steps of 45$^\circ$) are randomly determined,
+and will not be communicated until the production phase. For details about the
 Exploration Phase confer~\refsec{sec:exploration-phase}.
 
-The signal light of the MPS will show a yellow light until a report regarding this machine is sent.
-If the wrong MPS zone is sent, the light will start red flashing.
-If only the MPS zone is sent, the green light will be turn on.
-If the zone and rotation is correctly reported, the green light will be flashing and if the zone is correct but the rotation wrongly reported the red and green light will be on.
+The signal light of the MPS will show a yellow light until a report regarding
+this machine is sent.  If the wrong MPS zone is sent, the light will start red
+flashing.  If only the MPS zone is sent, the green light will be turn on.  If
+the zone and rotation is correctly reported, the green light will be flashing
+and if the zone is correct but the rotation wrongly reported the red and green
+light will be on.
 
 \begin{table}[bt]
   \centering
   \mytable{\begin{tabularx}{\linewidth}{p{0.36\linewidth}|X}
-      \multicolumn{1}{l}{Optical Feedback} & \multicolumn{1}{l}{Operating mode} \\ \hline
-      All LEDs turned off & The machine is physically offline, caused by a real error, which should not happen during the competition. \\
+      \multicolumn{1}{l}{Optical Feedback}
+      & \multicolumn{1}{l}{Operating mode}
+      \\
+      \hline
+      All LEDs turned off
+      & The machine is physically offline, caused by a real error, which should
+        not happen during the competition.
+      \\
       Red LED turned on & The machine is out of order. \\
-      %Red LED flashing (at 2 Hz)  & Machine signals that it ran out of stock on any required item. \\
+      %Red LED flashing (at 2 Hz)
+      %& Machine signals that it ran out of stock on any required item. \\
       Green LED turned on & The machine is idle and ready.\\
       Green LED flashing & The machine has accepted the prepare command
       (flashes for up to 3 seconds).\\
@@ -1416,25 +1537,24 @@ specified in Section~\ref{sec:machines}.
 \subsubsection{Machine Refill}
 \label{sec:machine-refill}
 The teams are responsible for restocking all materials (base elements,
-rings, prepared caps on shelves, and $C_0$ in the SS) before and during matches. Each
-team has to designate one team-member as a \textit{``replenisher''} who
-must be specified to the corresponding ``field half/team'' referee ahead
-of each game.  Only this team member will be allowed to access the
-field area and only in case of a recent refill procedure.  The
-replenisher must not obstruct other robots and should interfere as
-little as possible.  The machines can only be refilled when a magazine
-or shelf is empty. In this case the field-operator may enter the
-competition-area without asking the referee. Shelves have to be
+rings, prepared caps on shelves, and $C_0$ in the SS) before and during matches.
+Each team has to designate one team-member as a \textit{``replenisher''} who
+must be specified to the corresponding ``field half/team'' referee ahead of each
+game.  Only this team member will be allowed to access the field area and only
+in case of a recent refill procedure.  The replenisher must not obstruct other
+robots and should interfere as little as possible.  The machines can only be
+refilled when a magazine or shelf is empty. In this case the field-operator may
+enter the competition-area without asking the referee. Shelves have to be
 (re-)filled in all three reachable slots. % chktex 36
-The replenisher may restock only caps if transparent base elements have been
-put back to the shelf, once no cap is remaining on this shelf.
+The replenisher may restock only caps if transparent base elements have been put
+back to the shelf, once no cap is remaining on this shelf.
 
-The teams are partly free to choose their assembly and placement of
-products.
-For example, teams can fill any number of bases into a BS or are free to choose the color of caps for a CS,
-however teams are only allowed to fill the CS if the whole shelf is empty and then it has to be filled completely.
-The color assignment of bases on
-the BS and SS must be obeyed, as otherwise they will deliver the wrong
+The teams are partly free to choose their assembly and placement of products.
+For example, teams can fill any number of bases into a BS or are free to choose
+the color of caps for a CS, however teams are only allowed to fill the CS if the
+whole shelf is empty and then it has to be filled completely.  The color
+assignment of bases on the BS and SS must be obeyed, as otherwise they will
+deliver the wrong
 bases.
 
 \subsection{Special Events during a Match}
@@ -1558,33 +1678,62 @@ missing upon preparation will be subtracted later from points scored.
     \label{tab:scoring-production}
     \mytable{
       \begin{tabularx}{\linewidth}{p{7em}|X|p{4em}}
-        \multicolumn{1}{l}{Sub-task } &\multicolumn{1}{l}{Production
-          Phase} & \multicolumn{1}{l}{Points}\\\hline
-        Additional base & Feed an additional base into a ring station & $+2$\\
-        Finish $CC_0$ step & Finish the work order for a color requiring no additional base & $+5$\\
-        Finish $CC_1$ step & Finish the work order for a color requiring one additional base & $+10$\\
-        Finish $CC_2$ step  & Finish the work order for a color requiring two additional bases & $+20$ \\
-        Finish $C_1$ pre-cap & Mount the last ring of a $C_1$ product & $+10$ \\
-        Finish $C_2$ pre-cap & Mount the last ring of a $C_2$ product & $+30$ \\
-        Finish $C_3$ pre-cap & Mount the last ring of a $C_3$ product & $+80$ \\
-        Mount cap & Mount the cap on a product & $+10$ \\
-        Retrieve from SS & A workpiece has been requested from storage
-        and is ready for retrieval& $-10$ \\
-        Delivery & Deliver one of the final product variants to the
-        designated loading zone at the time specified in the order & $+20$\\
-        Delayed Delivery & An order delivered within 10 seconds after an
-        order is awarded a reduced score. For delivery time slot end
-        $T_e$ and actual delivery time $T_d$ in seconds the reduced
-        score is given by \newline $\lfloor 15 - \lfloor T_d - T_e \rfloor * 1.5 + 5 \rfloor$
-        & up to $+20$\\
+        \multicolumn{1}{l}{Sub-task }
+        & \multicolumn{1}{l}{Production Phase}
+        & \multicolumn{1}{l}{Points}
+        \\
+        \hline
+        Additional base & Feed an additional base into a ring station & $+2$
+        \\
+        Finish $CC_0$ step
+        & Finish the work order for a color requiring no additional base
+        & $+5$
+        \\
+        Finish $CC_1$ step
+        & Finish the work order for a color requiring one additional base
+        & $+10$
+        \\
+        Finish $CC_2$ step
+        & Finish the work order for a color requiring two additional bases
+        & $+20$
+        \\
+        Finish $C_1$ pre-cap & Mount the last ring of a $C_1$ product & $+10$
+        \\
+        Finish $C_2$ pre-cap & Mount the last ring of a $C_2$ product & $+30$
+        \\
+        Finish $C_3$ pre-cap & Mount the last ring of a $C_3$ product & $+80$
+        \\
+        Mount cap & Mount the cap on a product & $+10$
+        \\
+        Retrieve from SS
+        & A workpiece has been requested from storage and is ready for retrieval
+        & $-10$
+        \\
+        Delivery
+        & Deliver one of the final product variants to the designated loading
+        zone at the time specified in the order
+        & $+20$
+        \\
+        Delayed Delivery & An order delivered within 10 seconds after an order
+        is awarded a reduced score. For delivery time slot end $T_e$ and actual
+        delivery time $T_d$ in seconds the reduced score is given by \newline
+        $\lfloor 15 - \lfloor T_d - T_e \rfloor * 1.5 + 5 \rfloor$
+        & up to $+20$
+        \\
         Late Delivery & An order delivered after 10 seconds & +5 \\
         Wrong delivery & Deliver one of the final product variants to
         the designated loading zone out of the requested time range or
         after all products requested in the period have already been
         delivered
-        & $+1$\\
-        False delivery & Deliver an intermediate product & $0$\\
-        Obstruction & Deliver a workpiece to a machine of the opposing team & $-20$ \\\hline
+        & $+1$
+        \\
+        False delivery & Deliver an intermediate product & $0$
+        \\
+        Obstruction
+        & Deliver a workpiece to a machine of the opposing team
+        & $-20$
+        \\
+        \hline
         Round Total & A minimum of 0 points is awarded. & $\geq 0$ \\
       \end{tabularx}
     }
@@ -1592,10 +1741,19 @@ missing upon preparation will be subtracted later from points scored.
 
 	\bigskip
 
-	\subtable[Scoring scheme for game commentary]{\mytable{\begin{tabularx}{\linewidth}{p{7em}|X|p{2.4em}} \multicolumn{1}{l}{Task} &\multicolumn{1}{l}{Game Commentary} & \multicolumn{1}{l}{Points}\\\hline
-      Accepted Commentary & Commentate at least one half of the game continuously
-      on microphone in English (or the local language of the venue) to the public &  +10\\%\hline
-  \end{tabularx} }}
+  \subtable[Scoring scheme for game commentary]{
+    \mytable{
+      \begin{tabularx}{\linewidth}{p{7em}|X|p{2.4em}}
+        \multicolumn{1}{l}{Task}
+        & \multicolumn{1}{l}{Game Commentary}
+        & \multicolumn{1}{l}{Points}\\\hline
+        Accepted Commentary
+        & Commentate at least one half of the game continuously on microphone in
+        English (or the local language of the venue) to the public
+        &  +10
+      \end{tabularx}
+    }
+  }
 
   \caption{Scoring Schemes}
   \label{tab:scoring}
@@ -1732,8 +1890,9 @@ unsuccessful, a coin toss determines the higher ranked team.
 The best two teams of the playoff phase will advance to the grand
 finale, the remaining two teams will compete in the small finals for
 the third place. The team that scores more points after the regular
-game time wins. If there is no winner after the regular time, refer to section \refsec{sec:overtime}. If after this there is still no
-winner, a coin toss will decide.
+game time wins. If there is no winner after the regular time, refer to
+section \refsec{sec:overtime}. If after this there is still no winner,
+a coin toss will decide.
 
 \bigskip \hskip-\parindent{}
 The detailed seeding will be created at the event. Although the idea
@@ -1752,18 +1911,19 @@ scoring the first points during the extension will win.
 
 \subsection{Game Commentary}
 In addition to scoring in the exploration and the production phase,
-points are also awarded if a team provides an commentary on
-microphone to the public throughout the game as stated in \reftab{tab:scoring}. The commentary should
-communicate the overall problems to be solved within this league, the
-actual events taking place, but also give an insight on the own team
-and how they solved certain tasks. It does neither have to be perfect,
-nor to be a flawless stream of information. The commentary should be
-continuous, but short pauses are acceptable. At the end of the game
-the referees decide if the commentary duties were met. If both teams are willing to commentate
-on the game, the game time is shared according to the team
-specification (e.g., team 1 commentates the first half, team 2 the
-second half). However, the teams can also make custom arrangements to
-split the overall time.
+points are also awarded if a team provides an commentary on microphone
+to the public throughout the game as stated in \reftab{tab:scoring}.
+The commentary should communicate the overall problems to be solved
+within this league, the actual events taking place, but also give an
+insight on the own team and how they solved certain tasks. It does
+neither have to be perfect, nor to be a flawless stream of
+information. The commentary should be continuous, but short pauses are
+acceptable. At the end of the game the referees decide if the
+commentary duties were met. If both teams are willing to commentate on
+the game, the game time is shared according to the team specification
+(e.g., team 1 commentates the first half, team 2 the second half).
+However, the teams can also make custom arrangements to split the
+overall time.
 
 \subsection{Penalties}
 The catalog in \reftab{tab:infringements} represents the decision
@@ -2539,7 +2699,9 @@ obtained through\\
 %
 %\begin{figure}[h]
 %\centering
-%\subfigure[Drive unit with motor (1), encoder (2), omni-directional wheel (3)]{%
+%\subfigure[
+%  Drive unit with motor (1), encoder (2), omni-directional wheel (3)
+%]{%
 %  \label{fig:driveunit}%
 %  \begin{minipage}[b]{0.4\linewidth}
 %    \centering \includegraphics{driveunit.png}

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -2910,6 +2910,7 @@ obtained through\\
 \end{appendix}
 \end{document}
 
+% vim:filetype=tex:textwidth=80:shiftwidth=2:softtabstop=2:expandtab
 %%% Local Variables:
 %%% mode: latex
 %%% TeX-master: t

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -46,6 +46,16 @@
 \newcommand{\reflst}[1]{Figure~\ref{#1}}
 \newcommand{\reftab}[1]{Table~\ref{#1}}
 
+\newcommand{\SItextrange}[3][]{
+  \SI[
+  input-quotient=:,
+  output-quotient=\text{ to },
+  quotient-mode=symbol,
+  #1
+  ]
+  {#2}{#3}
+}
+
 \usepackage{floatrow}
 \newfloatcommand{capbtabbox}{table}[][\FBwidth]
 
@@ -158,7 +168,7 @@
 \setcounter{page}{1}
 \tableofcontents
 \newpage
-\cleardoublepage
+\cleardoublepage{}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%
@@ -206,7 +216,7 @@ partner Festo provides insights into future factory concepts to help
  systems. Opposed to numerous approaches regarding production
  infrastructure, RCLL aims to provide concepts for smart production
  logistics.
- 	
+
 After an exciting RoboCup in Nagoya, we look forward to a new scale of
 competition that will emerge from initiatives around the globe. In
 2012 we had our first Logistics League World Champion.  In 2013 we
@@ -372,7 +382,7 @@ league is available at\\
 \subsection{Field Layout and Dimensions}
 \label{sec:competition-area}
 \begin{figure}[p]
-    \includegraphics[width=\paperwidth, angle=-90 , trim = 0 0 0 0,]{field2017.pdf}
+    \includegraphics[width=\paperwidth, angle=-90, trim = 0 0 0 0,]{field2017.pdf}
     \vspace{1ex}
     \caption{Competition area: squares indicate zones for possible
       machine placements, circles denote robots. Cyan and magenta are
@@ -384,8 +394,8 @@ league is available at\\
     \label{fig:competition-area}
 \end{figure}
 The competition area is shown in \reffig{fig:competition-area} and
-features a \SI{14 x 8}{\metre} large arena with 106 square zones
-of \SI{1 x 1}{\metre} with 14 randomly distributed machines. The
+features a \SI{14 x 8}{\metre} large arena with 106 square zones %chktex 29
+of \SI{1 x 1}{\metre} with 14 randomly distributed machines. The % chktex 29
 field is partially surrounded (at least 50\% but not more than 70\%)
 by wall elements of at least \SI{0.5}{\metre} height.  The origin and
 coordinate system of the competition field is drawn in
@@ -453,9 +463,9 @@ Robots that leave the competition area illegally are considered as
 Machines are based on the Modular Production System (MPS)\footnote{For
   more information see
   \url{http://www.robocup-logistics.org/links/festo-mps}.} by Festo
-Didactic SE. The MPS provides a number of stations which
+Didactic SE\@. The MPS provides a number of stations which
 make up the machines used in the competition. The stations have a
-rectangular base shape of \SI{0,35 x 0,7}{\metre} with a height of
+rectangular base shape of \SI{0,35 x 0,7}{\metre} with a height of % chktex 29
 about \SI{1}{\metre} depending on machine type. The machine
 has individual application modules that provide different
 functionality.
@@ -593,15 +603,18 @@ phase. Processing times are outlined in \reftab{tab:processing-times}.
 
 \begin{table}[!tb]
     \centering
-    \mytable{  \begin{tabularx}{\linewidth}{l|l|X}
+    \mytable{
+        \begin{tabularx}{\linewidth}{l|l|X}
             Type & Distribution & (Final) processing time[s]\\\hline
             Base Station (BS) & 1 per team & minimum physical time\\
-            Cap Station (CS) & 2 per team & $t_2 = 15 \mbox{ to } 25~\mathrm{sec}$\\
-            Ring Station (RS) & 2 per team &$t_3 = 40 \mbox{ to } 60~\mathrm{sec}$\\
+            Cap Station (CS) & 2 per team & $t_2 = \SItextrange{15:25}{\sec}$\\
+            Cap Station (CS) & 2 per team & $t_2 = \SItextrange{15:25}{\sec}$\\
+            Ring Station (RS) & 2 per team &$t_3 = \SItextrange{40:60}{\sec}$\\
             Storage Station (SS) & 1 per team & minimum physical time\\
-            Delivery Station (DS) & 1 per team &$t_5 =20\mbox{ to } 40~\mathrm{sec}$
-    \end{tabularx}}
-    \caption{MPS - Type, Distribution and processing times}
+            Delivery Station (DS) & 1 per team &$t_5 =\SItextrange{20:40}{\sec}$
+        \end{tabularx}
+    }
+    \caption{MPS type, distribution and processing times}
     \label{tab:processing-times}
 \end{table}
 
@@ -744,14 +757,14 @@ half.
 
 For each game, one CS and one RS of each team will be chosen randomly
 and swapped with the corresponding machine of the other team on the
-non-primary half -- that is two machines in total per team. The CS and
+non-primary half --- that is two machines in total per team. The CS and
 RS will be swapped with the symmetrically positioned machine of the
 same type of the other team. For consecutive games, the changes to the
 machine to zone assignment may be limited by the referee box in order
 to reduce the time needed to implement the layout during the setup
 phase.
 
-\subsubsection{MPS -- During Exploration Phase}
+\subsubsection{MPS --- During Exploration Phase}
 \label{sec:production-machines-exp}
 During the exploration phase the robots of each team must explore the
 unknown factory environment to identify where the different MPS are
@@ -786,12 +799,12 @@ If the zone and rotation is correctly reported, the green light will be flashing
       machine.\\%\hline
 %%keep Red any Yellow one?
 	\end{tabularx}}
-  \caption{MPS - Optical Feedback during production phase}
+  \caption{MPS --- Optical Feedback during production phase}
   \label{tab:production-machines-feedback}
 \end{table}
 
 \vspace*{-2mm}
-\subsubsection{MPS -- During Production Phase}
+\subsubsection{MPS --- During Production Phase}
 \label{sec:production-machines-production}
 In the production phase a production machine performs refinement steps on
 a product such as mounting an additional ring or a cap. Machines
@@ -853,7 +866,7 @@ prepared on the shelf are specially colored workpieces (clear). The
 machine will take the cap off the base and buffer it on the slide,
 releasing the decapped base to the output side. This base can only be
 used for providing an additional base to an RS (see below), reuse by
-placing it back on the shelf, or discarding it at the DS.  For
+placing it back on the shelf, or discarding it at the DS\@.  For
 mounting a cap, a workpiece (without cap) must be provided onto which
 the cap is mounted.
 
@@ -943,7 +956,7 @@ The workpieces consist of the following elements:
   (cf.~\refsec{sec:production-machines-production}), they cannot be
   used as a workpiece for production. They may, however, be used to
   provide additional bases required by an RS, stored on a team's CS
-  shelf, or recycled at the DS.
+  shelf, or recycled at the DS\@.
 \item[Ring] Rings are mounted in intermediate production steps at ring
   stations (RS). A product requires, zero, one, two, or three
   intermediate rings of distinct color
@@ -971,7 +984,7 @@ operations involving workpieces.
 All bases are labeled by a horizontally revolving, white glossy tag
 covering about 50 percent of the bases height (from the center)
 containing a white reference area as well as an identifying
-barcode. Each base is equipped with a unique ID. \reffig{fig:barcode}
+barcode. Each base is equipped with a unique ID\@. \reffig{fig:barcode}
 shows a prototype of a barcode labeled workpiece.
 
 The barcodes are scanned at each station and communicated to the
@@ -1078,8 +1091,8 @@ should be handled in a fair and forthcoming way.
 \section{Game Play}
 A match is defined by two contesting teams competing within the same
 identical competition area. Each team consists of a maximum of 3
-robots. Each has three phases -- for setup, exploration, and
-production -- which are detailed below.
+robots. Each has three phases --- for setup, exploration, and
+production --- which are detailed below.
 
 \subsection{Environment Setup}
 \label{sec:env-setup}
@@ -1204,7 +1217,7 @@ updated. The scoring is shown in \reftab{tab:scoring-exploration}. A
 minimum of zero points will be accounted for the exploration
 phase. The exploration phase ends either after the time has passed or
 immediately after both teams have each reported their respective set
-of MPS.
+of MPS\@.
 
 Moving or processing workpieces at an MPS is not allowed during the
 exploration phase.
@@ -1240,7 +1253,7 @@ therefore distinguish \emph{color complexities} as $CC_0$, $CC_1$, and
 $CC_2$ depending on whether zero, one, or two additional bases are
 required for a color. The referee box ensures that there will always
 be some orders for $C_1$ products where the ring color does not
-require additional bases, i.e., with color complexity $CC_0$ -- but
+require additional bases, i.e., with color complexity $CC_0$ --- but
 not necessarily all $C_1$ orders have this constraint.
 
 \begin{figure}
@@ -1404,17 +1417,17 @@ specified in Section~\ref{sec:machines}.
 \label{sec:machine-refill}
 The teams are responsible for restocking all materials (base elements,
 rings, prepared caps on shelves, and $C_0$ in the SS) before and during matches. Each
-team has to designate one team-member as a \textit{"replenisher"} who
-must be specified to the corresponding "field half/team" referee ahead
+team has to designate one team-member as a \textit{``replenisher''} who
+must be specified to the corresponding ``field half/team'' referee ahead
 of each game.  Only this team member will be allowed to access the
 field area and only in case of a recent refill procedure.  The
 replenisher must not obstruct other robots and should interfere as
 little as possible.  The machines can only be refilled when a magazine
 or shelf is empty. In this case the field-operator may enter the
 competition-area without asking the referee. Shelves have to be
-(re)filled in all three reachable slots. The replenisher may restock
-only caps if transparent base elements have been put back to the
-shelf, once no cap is remaining on this shelf.
+(re-)filled in all three reachable slots. % chktex 36
+The replenisher may restock only caps if transparent base elements have been
+put back to the shelf, once no cap is remaining on this shelf.
 
 The teams are partly free to choose their assembly and placement of
 products.
@@ -1435,7 +1448,7 @@ time will be paused during the interruption.
 \subsubsection{Scheduled Machine Downtime}
 \label{sec:out-of-order}
 The refbox will take down machines randomly out of the pool containing
-the RS and CS. It will do so at random points of time and with the
+the RS and CS\@. It will do so at random points of time and with the
 same conditions for both teams, i.e., affecting the same machines for
 both teams. There will be 2 of such triggered events during a
 match. The machines affected will remain out of order for 30 to 60
@@ -1499,7 +1512,7 @@ announced cannot be awarded.
 
 There is a special case regarding the Storage Station. Retrieving a
 workpiece has a cost (see \reftab{tab:scoring}). The cost is
-subtracted as soon as the workpiece is ready for retrieval on the SS.
+subtracted as soon as the workpiece is ready for retrieval on the SS\@.
 However, exploration points gained during the exploration will not be
 used for this. If the team has not yet received sufficient points,
 workpieces can be ``purchased on (partial) credit''. Points that were
@@ -1513,13 +1526,30 @@ missing upon preparation will be subtracted later from points scored.
 
      \mytable{
          \begin{tabularx}{\linewidth}{p{7em}|X|p{2.4em}}
-           \multicolumn{1}{l}{Report type} &\multicolumn{1}{l}{Description} & \multicolumn{1}{l}{Points}\\\hline
-      	Zone/Orientation & Correctly determine a machine zone and the rotation of your team and report it successfully to the refbox & +2\\
-	     Type & only machine zone reported & +1\\
- 	 	& Machine zone reported correctly but orientation wrongly (1-1=0) & 0\\
-		& wrongly reported machine zone (orientation irrelevant) & -1\\\hline
-           Round Total &  A maximum of 14 points can be achieved by correctly reporting all 7 production machines. A minimum of 0 points is
-    awarded. & 0 -- 14\\
+           \multicolumn{1}{l}{Report type}
+           & \multicolumn{1}{l}{Description}
+           & \multicolumn{1}{l}{Points}\\
+           \hline
+          Zone/Orientation
+          & Correctly determine a machine zone and the rotation of your team
+            and report it successfully to the refbox
+          & $+2$
+          \\
+          Type
+          & only machine zone reported
+          & $+1$
+          \\
+          & Machine zone reported correctly but orientation wrongly ($1-1=0$)
+          & $0$
+          \\
+		      & wrongly reported machine zone (orientation irrelevant)
+          & $-1$
+          \\
+          \hline
+          Round Total
+          & A maximum of 14 points can be achieved by correctly reporting all
+            7 production machines. A minimum of 0 points is awarded.
+          & \SItextrange{0:14}{}
   \end{tabularx} }}
 
 \bigskip
@@ -1579,12 +1609,12 @@ compete alongside each other, instead of directly against each other, we
 punish intentional obstruction of the opposing team.
 
 This applies in particular to the input and output area in front of
-any MPS.  All robots are allowed to enter this space, but robots must
+any MPS\@.  All robots are allowed to enter this space, but robots must
 not obstruct opposing robots which intend to approach their
-MPS. Concretely, that robot must give way and release an approachable
+MPS\@. Concretely, that robot must give way and release an approachable
 path to the MPS within a time window of 10 seconds. If a robot cannot
-follow this rule, a pushing foul will be called according to Section
-\ref{sec:pushing-rules}.
+follow this rule, a pushing foul will be called according to
+Section~\ref{sec:pushing-rules}.
 
 % old ?!
 Furthermore, teams are penalized for obstruction according to
@@ -1649,7 +1679,7 @@ to pushing.
 \item Moving a workpiece of the opposing team at their MPS is a pushing
 foul. The referee will move the workpiece back to its original position.
 \item Intentional obstruction of the opposing team is a pushing foul, as
-described in Section \ref{sec:obstruction-penalty}.
+described in Section~\ref{sec:obstruction-penalty}.
 \item If a robot is restarted or called to maintenance, loses his
 workpiece during collision avoidance or in case of a collision, the
 workpiece will not be replaced and is removed by the referee.
@@ -1684,8 +1714,8 @@ team in this phase directly competes with an opposing team, a ranking
 score will be determined as follows. In each \emph{game}, the winning
 team gets 3 ranking points, the loosing team gets 0. A team wins if it
 achieves more points in the game than the other team
-(cf. Sections~\ref{sec:exploration-phase} and
-\ref{sec:production-phase}). In the case of a non-zero draw, see section \refsec{sec:overtime} for overtime.
+(cf.~Sections~\ref{sec:exploration-phase} and~\ref{sec:production-phase}). In
+the case of a non-zero draw, see Section~\refsec{sec:overtime} for overtime.
 If, after overtime, a draw is not
 resolved, both teams get 1 ranking point. If both team end with a zero
 score, each team gets 0 ranking points.
@@ -1705,7 +1735,7 @@ the third place. The team that scores more points after the regular
 game time wins. If there is no winner after the regular time, refer to section \refsec{sec:overtime}. If after this there is still no
 winner, a coin toss will decide.
 
-\bigskip \hskip-\parindent
+\bigskip \hskip-\parindent{}
 The detailed seeding will be created at the event. Although the idea
 is to allow each participant to challenge each other team, the league
 can be adjusted to meet time requirements.
@@ -1814,7 +1844,7 @@ machine or the environment. The general idea is to test this as an
 advancement of the league for future events. Distances between robots
 and the machine are measured as the shortest distance from MPS trolley
 to robot base on the ground. The maximum achievable score in this
-challenge is 40 points -- up to 10 for the recognition and production
+challenge is 40 points --- up to 10 for the recognition and production
 parts each, up to 10 for the explanation and methodologies, and up to
 10 for the public release of the source code.
 
@@ -1825,7 +1855,7 @@ must approach the machine one after another and use only sensors
 mounted on the robot to recognize the physical type of the
 machine. The machines can be of any type.
 
-The recognition part scores up to 10 points -- 5 points for each
+The recognition part scores up to 10 points --- 5 points for each
 machine. Of these 5 points, 2 points are awarded for proper approach
 (robot standing at the input or output side of the machine facing
 towards the machine with a distance of no more than \SI{0.5}{\metre})
@@ -1866,8 +1896,8 @@ five points.
 \subsubsection{Playing in Simulation}
 
 The challenge is to play the production phase of an RCLL game, based
-on the publicly released Gazebo-based simulation
-\cite{llsf-sim-rc2014-2014}. The simulation
+on the publicly released Gazebo-based simulation~\cite{llsf-sim-rc2014-2014}.
+The simulation
 software\footnote{\url{https://www.fawkesrobotics.org/projects/rcll-sim/}}
 including technical documentation is publicly available on
 Github.\footnote{\url{https://github.com/robocup-logistics/gazebo-rcll}}
@@ -1915,7 +1945,7 @@ website.
 %
 We will follow the ICAPS competition's setup and will provide two
 principal interfaces: one based on Fawkes, and another based on
-ROS. Please see the ICAPS competition's rules and regulations for the
+ROS\@. Please see the ICAPS competition's rules and regulations for the
 details.
 
 \vspace{-2ex}\paragraph{Robot Models and Plugins}
@@ -1931,7 +1961,7 @@ make sure that the standard set of sensors
 provided is sufficient.
 
 \vspace{-2ex}\paragraph{Competition Area} The competition area can be
-expected to be similar to Figure \ref{fig:competition-area}, however,
+expected to be similar to Figure~\ref{fig:competition-area}, however,
 the MPS locations will be randomized as in the real game.
 
 \vspace{-2ex}\paragraph{Abstraction Level} Teams need to utilize their
@@ -2310,7 +2340,7 @@ switching sensor.
 \label{fig:robotinos}
 \end{figure}
 
-\hskip-\parindent The motor speed will be controlled via a PID
+\hskip-\parindent{} The motor speed will be controlled via a PID
 controller implemented on a Atmel microprocessor of the controller
 board of Robotino.
 
@@ -2340,7 +2370,7 @@ HD 1080p video with auto light correction and two built in microphones
 for stereo sound with noise-canceling.
 
 \subsubsection{Controller Board}
-Robotino is powered by an exchangeable Embedded PC - COM Express
+Robotino is powered by an exchangeable Embedded PC-COM Express
 layout combined with a custom made sensor board.
 
 \paragraph{Embedded PC according to COM Express specification}
@@ -2376,12 +2406,13 @@ layout combined with a custom made sensor board.
 
 \subsubsection{Power supply}
 \begin{itemize}
-\item 2 $\times$ 12 V lead-fleece rechargeable batteries with 9.5 Ah
-  capacity each
-\item Operating time(default batteries): up to 4 hours
-\item Power supply for additional components: 13 x 24 V, 13 x GND
+  \item $2 \times \SI{12}{\volt}$ lead-fleece rechargeable batteries with
+    $\SI{9.5}{Ah}$ capacity each
+  \item Operating time (default batteries): up to $\SI{4}{\hour}$
+\item Power supply for additional components: $13 \times \SI{24}{\volt}$,
+  $13 \times \text{GND}$
 \item Internal charger for lead-gel and NiMH rechargeable batteries
-\item 24 V power supply for charging batteries
+\item $\SI{24}{\volt}$ power supply for charging batteries
 \end{itemize}
 
 \subsubsection{Software}
@@ -2395,7 +2426,7 @@ in numerous programming languages:
 \begin{itemize}
 \item C++ and C
 \item C\#
-\item .net and JAVA
+\item {.net} and JAVA
 \item MatLab and Simulink
 \item Labview
 \item Robot Operating System (ROS)
@@ -2426,7 +2457,7 @@ external PC running on Windows XP, Vista, Windows 7 or Windows 8.
 \item Program interpreter to run programs on Embedded PC autonomously
 \end{itemize}
 
-\hskip-\parindent Additional information as well as accessories can be
+\hskip-\parindent{} Additional information as well as accessories can be
 obtained through\\
 \url{http://www.robocup-logistics.org/links/festo-robotino-3}.
 
@@ -2690,7 +2721,7 @@ obtained through\\
       Transfer rate		&	Up to \SI{108}{\mega\bit\per\second} \\
       Data link protocol	&	802.11 a/g/n \\
       Frequency			&	\SI{5.0}{\giga\hertz} \\
-      IP-distribution		&	172.26.200.xxx for LAN clients(DHCP) \\
+      IP-distribution		&	172.26.200.xxx for LAN clients (DHCP) \\
       &	172.26.101.xxx for the Robotino devices \\
       &	172.26.1.xxx for Robotinos \\
       Subnet Mask			&	255.255.0.0 \\
@@ -2701,7 +2732,7 @@ obtained through\\
       Festo Clients		&	3COM WL-560 \\
       Power Supply		&	Clients: \SI{12}{\volt}, \SI{1}{\ampere},\\
       & 	Most Laptops cannot power them \\
-      & 	via USB! \\
+      & 	via USB\@! \\
       Connector			&	Ethernet \\
 
 %      \hline
@@ -2712,7 +2743,7 @@ obtained through\\
 
 
 
-\printbibliography
+\printbibliography{}
 
 \end{appendix}
 \end{document}


### PR DESCRIPTION
1. Add a Makefile to
    * build the rulebook by invoking `latexmk`
    * run the latex linter `chktex` and make sure that there are no warnings
    * check that the file is encoded with UTF-8 without BOM (this tests the build error in #15 and gives a more explicit error message)
    * check that the maximum linewidth is 80
2. Adapt the rulebook to pass all the tests above
3. Add the tests to circleci so they are run automatically

