### PR TITLE
Remove gate from DS prepare message

### DIFF
--- a/rulebook.tex
+++ b/rulebook.tex
@@ -973,11 +973,9 @@ be dispensed. After receiving the message, the refbox will instruct
 the MPS to immediately provide a base of the desired color.
 
 \noindent\textbf{DS}
-The DS prepare message denotes the slide the product should be delivered
-to, as well as the order ID of the product that is delivered.  The DS
-will consume any workpiece provided, but points can only be scored if
-the DS has been properly prepared with the correct slide and order ID
-as requested by the refbox.
+The DS prepare message denotes the order ID of the product that is delivered.
+The DS will consume any workpiece provided, but points can only be scored if the
+DS has been properly prepared.
 
 \noindent\textbf{CS}
 The CS prepare message initiates either the retrieval or the mounting of

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -537,12 +537,9 @@ Based on these shared properties, there are five kinds of machines:
   layer).\footnote{Note that this is the specific content for 2018 and
   may change in the future.}
 
-\item[Delivery Station (DS)] Accepts completed products. The stations
-  contains three slides (\reffig{fig:DS}). The robot has to prepare
-  the proper one for a specific order
-  (cf. \refsec{sec:production-machines-production}). The delivered
-  products are verified by either the referees or an automated
-  external vision system. There is one DS per team.
+\item[Delivery Station (DS)] Accepts completed products. The stations contains
+  three slides (\reffig{fig:DS}). The delivered products are verified by either
+  the referees or an automated external vision system. There is one DS per team.
 \end{description}
 
 \noindent


### PR DESCRIPTION
As discussed at today's TC meeting, we no longer want the gate to be part of the DS prepare message. We already have the order ID (since #1), therefore sending the gate is redundant.

Also remove some redundant information in the rulebook about DS preparation to avoid inconsistencies.