### PR TITLE
gitignore: ignore files generated by latexmk and vim's swap file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@
 /rulebook2015.pdf
 /rulebook2016.pdf
 /rulebook2017.pdf
+*.fdb_latexmk
+*.fls
+*.synctex.gz
+*.swp


### PR DESCRIPTION
Add some common files to gitignore to avoid accidental commits containing those files, as in #13.