### PR TITLE
github: remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @dka14 @morxa @MostafaGomaa @teamsolidus @thomerz @timn @vcoelen


### PR DESCRIPTION
We no longer use PR approvals as way of voting, therefore, there is no
need for the CODEOWNERS anymore. With the new workflow, it makes more
sense to request a review from someone specifically, not from the whole
TC.