### PR TITLE
Rework rules regarding order schedule

### DIFF
--- a/rulebook.tex
+++ b/rulebook.tex
@@ -2122,8 +2122,8 @@ following criteria:
       \\\hline
       C1 & $[120,300]\si{\second}$           & $[\phantom{1}90,180]\si{\second}$
       \\\hline
-      C2 & $[300,600]\si{\second}$           & $[150,210]\si{\second}$\\\hline
-      C3 & $[300,600]\si{\second}$           & $[150,210]\si{\second}$
+      C2 & $[300,400]\si{\second}$           & $[150,210]\si{\second}$\\\hline
+      C3 & $[400,500]\si{\second}$           & $[150,210]\si{\second}$
     \end{tabular}
     \caption{Order time randomization ranges.}
     \label{tab:order-time-randomization}

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -2079,43 +2079,60 @@ The ring colors which
 require additional bases are randomized per game and announced by the
 refbox. There will be one color requiring 2 additional bases, one
 requiring 1 base, and two colors requiring no additional base at
-all. Products retrieved from the Storage Station may be used only for
-$C_0$ orders with a requested quantity equal to or greater than two.
+all.
 
-In each game, up to 9 orders will be placed within the regular game.
-1 of those orders will be \emph{competitive}, while the remaining
-orders will be \emph{non-competitive}. In case of overtime, an
-additional competitive order will be placed.\footnote{The numbers can
-be adjusted during the tournament by the Technical Committee, should
-this turn out to be necessary.}
-The complexities of orders will be similar for all games within a
-tournament phase. But the actual production chains are randomized.
-Each order will require one or more products of a specified product
-type to be delivered. A competitive order always requires exactly one
-product to be delivered. The product is specified in terms of base
-color, rings (color and order), cap color, and possible delivery gate.
-The delivery time slot will have a randomized start time. The duration
-will be randomized between 30 to 180 seconds. The end time shall be
-within the game time. There is not necessarily an open order for a
-particular product at a specific time, or any order at all. The first
-order will be posted within the first 120 seconds of the game (but not
-necessarily at the beginning of the game). Orders for the products of
-complexity $C_2$ or $C_3$ will not begin in the first 300 seconds. An
-order will be announced before the delivery time slots starts. For
-$C_0$ products the lead time ahead of the start of the time window is
-60 to 120 seconds, for $C_1$ it is 120 to 300 seconds, and for $C_2$
-and $C_3$ orders the time is between 300 and 600 seconds. Two early
-orders will be posted that are announced in the first third of the
-game with a delivery time window in the last third. For each of the
-complexities $C_0$ and $C_1$ a standing order for a single product
-will be placed at the beginning of the production phase, which can be
-fulfilled at any time during the game. Competitive orders are always for
-products of complexity $C_0$. A competitive order cannot be a standing order.
+In each game, up to 10 orders will be placed within the regular game.
+Each order will require one product of a specified product
+type to be delivered.
+The product is specified in terms of base
+color, rings (color and order) and cap color.
+% TODO: is the delivery gate actually sent
+3 time points are attached to each order:
+At its \emph{activation time}, the \ac{refbox} announces the order to each
+team along with a \emph{delivery start time} and a \emph{delivery end time}
+(deadline).
 
-The \ac{refbox} ensures that there will always
-be some orders for $C_1$ products where the ring color does not
-require additional bases, i.e., with color complexity $CC_0$ --- but
-not necessarily all $C_1$ orders have this constraint.
+At the beginning of the game, 2 orders are announced, one with complexity
+C0 or C1, the other with complexity C2 or C3. In any case, the first ring
+(if any) of either of this two orders is of color complexity $CC_0$
+(costs no additional bases to mount).
+
+The remaining 8 orders are dispatched throughout the game according to the
+following criteria:
+\begin{itemize}
+  \item 50\% are of complexity C2 or C3, the other 50\% are of complexity C0 or
+    C1.
+    Hence the complexities of orders will be similar for all games within a
+    tournament phase. But the actual production chains are randomized.
+  \item Exactly one order is competitive, while the remaining orders will be
+    \emph{non-competitive}.
+  \item The activation times are roughly evenly spaced between minute 3 and
+    minute 16 (every \SI{90}{\second} with deviations of up to
+    \SI{180}{\second}, but always between minute 3 and 16).
+  \item The time between activation and delivery start (production window) is
+    randomized and based on the complexity of the product.
+    Similarly the time between delivery start and end (delivery window)
+    is randomized as indicated in \reftab{tab:order-time-randomization}
+    \begin{center}
+
+    \begin{table}
+    \begin{tabular}{l|r|r}
+      \bf{complexity} & \bf{production window} & \bf{delivery window} \\
+      C0 & $[\phantom{1}60,120]\si{\second}$ & $[\phantom{1}90,180]\si{\second}$
+      \\\hline
+      C1 & $[120,300]\si{\second}$           & $[\phantom{1}90,180]\si{\second}$
+      \\\hline
+      C2 & $[300,600]\si{\second}$           & $[150,210]\si{\second}$\\\hline
+      C3 & $[300,600]\si{\second}$           & $[150,210]\si{\second}$
+    \end{tabular}
+    \caption{Order time randomization ranges.}
+    \label{tab:order-time-randomization}
+    \end{table}
+    \end{center}
+\end{itemize}
+
+In case of overtime, an
+additional competitive order will be placed.
 
 Teams playing on the field at the same time will get the same
 production plan. However, each game will use a new randomized order

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -2135,7 +2135,7 @@ following criteria:
 \end{itemize}
 
 In case of overtime, an
-additional competitive order will be placed.
+additional competitive order of complexity C0 will be placed.
 
 Teams playing on the field at the same time will get the same
 production plan. However, each game will use a new randomized order

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -2129,6 +2129,9 @@ following criteria:
     \label{tab:order-time-randomization}
     \end{table}
     \end{center}
+  \item Color combinations of bases and rings are unique across orders, so it
+    is not possible to have a started product with a ring that could belong to
+    multiple orders.
 \end{itemize}
 
 In case of overtime, an

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -2081,7 +2081,7 @@ refbox. There will be one color requiring 2 additional bases, one
 requiring 1 base, and two colors requiring no additional base at
 all.
 
-In each game, up to 10 orders will be placed within the regular game.
+In each regular game, up to 10 orders will be posted.
 Each order will require one product of a specified product
 type to be delivered.
 The product is specified in terms of base

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -2107,8 +2107,8 @@ following criteria:
   \item Exactly one order is competitive, while the remaining orders will be
     \emph{non-competitive}.
   \item The activation times are roughly evenly spaced between minute 3 and
-    minute 16 (every \SI{90}{\second} with deviations of up to
-    \SI{180}{\second}, but always between minute 3 and 16).
+    minute 16 (every \SI{120}{\second} with deviations of up to
+    \SI{90}{\second}, but always between minute 3 and 16).
   \item The time between activation and delivery start (production window) is
     randomized and based on the complexity of the product.
     Similarly the time between delivery start and end (delivery window)

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -2296,7 +2296,7 @@ Each slot can be used to do at most one challenge and the corresponding
 challenge is carried out according to the following procedure:
 \begin{enumerate}
   \item The \ac{refbox} is configured for the respective challenge and in case
-    the challenge s carried out remotely, the live stream is started.
+    the challenge is carried out remotely, the live stream is started.
     The \texttt{SETUP} phase begins, see \refsec{sec:setup-phase}.
 	\item Then the \texttt{PRODUCTION} phase starts by instructing the referee
     box accordingly.


### PR DESCRIPTION
Simplify the rules around possible delivery and production windows, such that they can be clearly described now.
The new system is:
 - 50% of products are of complexity C0 or C1, the other 50% are C2 or C3
 - orders arrive according to a set pattern (every 90+x seconds, x in [-180,180]
 - orders arrive between minute 3 and 16 (except for 2 standing orders)
 - standing orders are one C0/C1 and one C2/C3, first ring being free of payment
 - explicitly mention that color combinations of complex products are unique, e.g., it is impossible to "upgrade" a started C2 to a C3