### PR TITLE
add rule regarding pre-stored products in main track

### DIFF
--- a/rulebook.tex
+++ b/rulebook.tex
@@ -2233,6 +2233,10 @@ following criteria:
 In case of overtime, an
 additional competitive order of complexity C0 will be placed.
 
+In each game each team is allowed to fulfill a single order of complexity by
+utilizing a pre-stored C0 from the storage station.
+However, the overtime order can not be fulfilled using pre-stored products.
+
 Teams playing on the field at the same time will get the same
 production plan. However, each game will use a new randomized order
 schedule.


### PR DESCRIPTION
I noticed that there was no mention of pre-stored products after the changes to a new order schedule.
My simple proposal is to allow at most 1 pre-stored C0 to be used for now. That is consistent with the old ruling, where it could only be used for one order.