### PR TITLE
mention barcode format and remove wrong code height specification

### DIFF
--- a/barcodes/barcode_generator.bash
+++ b/barcodes/barcode_generator.bash
@@ -9,11 +9,12 @@ COLOR_DIGITS=2
 PREFIX_DIGITS=$(( $MAX_DIGITS-$QUANTITY_DIGITS-$COLOR_DIGITS ))
 RANGE_START=0
 RANGE_END=2
-NUM_COLORS=3
+NUM_COLORS=4
 
-# red    xx0xxx
-# silver xx1xxx
-# black  xx2xxx
+# red          xx0xxx
+# silver       xx1xxx
+# black        xx2xxx
+# transparent  xx3xxx
 
 color () {
 	if (( $1 == 0 ))
@@ -27,6 +28,10 @@ color () {
 	if (( $1 == 2 ))
 		then
 			echo "slv"
+	fi
+	if (( $1 == 3 ))
+		then
+			echo "tra"
 	fi
 }
 

--- a/barcodes/barcode_generator.bash
+++ b/barcodes/barcode_generator.bash
@@ -1,0 +1,119 @@
+#! /bin/bash
+#
+# barcode_generator.bash
+# Copyright (C) 2022 Tarik Viehmann <viehmann@kbsg.rwth-aachen.de>
+
+MAX_DIGITS=6
+QUANTITY_DIGITS=2
+COLOR_DIGITS=2
+PREFIX_DIGITS=$(( $MAX_DIGITS-$QUANTITY_DIGITS-$COLOR_DIGITS ))
+RANGE_START=0
+RANGE_END=2
+NUM_COLORS=3
+
+# red    xx0xxx
+# silver xx1xxx
+# black  xx2xxx
+
+color () {
+	if (( $1 == 0 ))
+		then
+	 	echo	"red"
+	fi
+	if (( $1 == 1 ))
+		then
+			echo "blk"
+	fi
+	if (( $1 == 2 ))
+		then
+			echo "slv"
+	fi
+}
+
+PRINT_HELP_AND_EXIT=0
+if [[ -z "$1" || -z "$2" ]]
+	then
+		PRINT_HELP_AND_EXIT=1
+		echo "Expected a range of barcode numbers to generate. Abort."
+	else
+		RANGE_START=$1
+		RANGE_END=$2
+	if [[ "$1" == "-h" ]]
+		then
+			PRINT_HELP_AND_EXIT=1
+		else
+			echo $1
+			if (( $1 >= $((10**$QUANTITY_DIGITS))  || $1 < 0 ))
+				then
+					echo "Argument 1 out of range. Abort"
+					PRINT_HELP_AND_EXIT=1
+			fi
+			if (( $2 >= $((10**$QUANTITY_DIGITS))  || $2 < 0 ))
+				then
+					echo "Argument 2 out of range. Abort"
+					PRINT_HELP_AND_EXIT=1
+			fi
+			if (( $2 > $3))
+				then
+					echo "Argument 1 cannot be greater than argument 2. Abort"
+					PRINT_HELP_AND_EXIT=1
+			fi
+	fi
+
+	if [[ -z "$3" ]]
+		then
+			PREFIX=$(printf "%0${PREFIX_DIGITS}d" $(( $RANDOM % (10**$PREFIX_DIGITS) )))
+		else
+		PREFIX=$3
+		if (( $3 >= $((10**$PREFIX_DIGITS)) ||  $3 < 0 ))
+			then
+				PRINT_HELP_AND_EXIT=1
+		fi
+	fi
+fi
+HELP="
+./barcodes_generator.bash <start-number> <end-number> [<prefix>]
+where: <start-number> and <end-number> range between 0 and $((10**$QUANTITY_DIGITS-1))
+       <prefix> is a number between 0 and $((10**$PREFIX_DIGITS-1))
+                which is used as prefix of every barcode
+                leave empty to get random value
+
+Creates a directory called <prefix> containing pdfs of the barcodes and
+a tex file that can generate a convenient format for printing.
+"
+
+if [[ $PRINT_HELP_AND_EXIT == 1 ]]
+then
+	echo "$HELP"
+	exit 1
+fi
+
+PWD=$(pwd)
+mkdir -p $PREFIX
+cd $PREFIX
+cp ../printable_barcodes.boilerplate.tex printable_barcodes.tex
+count=0
+for col in $(seq 0 $(($NUM_COLORS-1)) )
+do
+	for i in $(seq $RANGE_START $RANGE_END)
+	do
+		res="$PREFIX$(printf %0${COLOR_DIGITS}d $col)$(printf %0${QUANTITY_DIGITS}d $i)"
+		barcode ''-b $res -e upc-e -E -n -o $res.eps'' &>/dev/null
+		epstopdf $res.eps &>/dev/null
+		rm $res.eps &
+		pdfcrop $res.pdf $res.pdf &>/dev/null
+		count_mod=$(($count % 20))
+		if (($count_mod == 0))
+		then
+			#cat ../printable_barcodes.tex.template >> printable_barcodes.tex
+			sed -i '/@@CONTENT@@/e cat ../printable_barcodes.template.tex ' printable_barcodes.tex
+		fi
+		sed -i "s|@@${count_mod}@@|${res}|g" printable_barcodes.tex
+		sed -i "s|@@color${count_mod}@@|$(color $col)|g" printable_barcodes.tex
+		count=$(($count + 1))
+	done
+done
+		sed -i "s|.*@@.*@@.pdf}}||g" printable_barcodes.tex
+		sed -i "s|@@.*@@||g" printable_barcodes.tex
+
+cd $PWD

--- a/barcodes/printable_barcodes.boilerplate.tex
+++ b/barcodes/printable_barcodes.boilerplate.tex
@@ -1,0 +1,10 @@
+% vim:ft=tex:
+%
+\documentclass[6pt]{article}
+\usepackage[margin=0mm]{geometry}
+\usepackage{arydshln}
+\usepackage{graphicx}
+
+\begin{document}
+% @@CONTENT@@
+\end{document}

--- a/barcodes/printable_barcodes.template.tex
+++ b/barcodes/printable_barcodes.template.tex
@@ -12,9 +12,9 @@
 	\rotatebox{90}{@@color8@@ @@8@@}\resizebox{13cm}{\height}{\includegraphics[angle=90]{@@8@@.pdf}}\\[0.01cm]\hdashline\noalign{\vskip 0.1cm}
 	\rotatebox{90}{@@color9@@ @@9@@}\resizebox{13cm}{\height}{\includegraphics[angle=90]{@@9@@.pdf}}\\[0.01cm]\hdashline\noalign{\vskip 0.1cm}
 	\rotatebox{90}{@@color10@@ @@10@@}\resizebox{13cm}{\height}{\includegraphics[angle=90]{@@10@@.pdf}}\\[0.01cm]\hdashline\noalign{\vskip 0.1cm}
-	\rotatebox{90}{@@color11@@ @@11@@}\resizebox{13cm}{\height}{\includegraphics[angle=90]{@@11@@}}\\[0.01cm]\hdashline\noalign{\vskip 0.1cm}
-	\rotatebox{90}{@@color12@@ @@12@@}\resizebox{13cm}{\height}{\includegraphics[angle=90]{@@12@@}}\\[0.01cm]\hdashline\noalign{\vskip 0.1cm}
-	\rotatebox{90}{@@color13@@ @@13@@}\resizebox{13cm}{\height}{\includegraphics[angle=90]{@@13@@}}
+	\rotatebox{90}{@@color11@@ @@11@@}\resizebox{13cm}{\height}{\includegraphics[angle=90]{@@11@@.pdf}}\\[0.01cm]\hdashline\noalign{\vskip 0.1cm}
+	\rotatebox{90}{@@color12@@ @@12@@}\resizebox{13cm}{\height}{\includegraphics[angle=90]{@@12@@.pdf}}\\[0.01cm]\hdashline\noalign{\vskip 0.1cm}
+	\rotatebox{90}{@@color13@@ @@13@@}\resizebox{13cm}{\height}{\includegraphics[angle=90]{@@13@@.pdf}}
 \end{tabular}
 \end{minipage}
 \begin{minipage}[t]{5cm}

--- a/barcodes/printable_barcodes.template.tex
+++ b/barcodes/printable_barcodes.template.tex
@@ -1,0 +1,32 @@
+
+	\vspace*{0.2cm}
+\begin{minipage}[t]{14cm}
+\begin{tabular}{c}
+	\rotatebox{90}{@@color1@@ @@1@@}\resizebox{13cm}{\height}{\includegraphics[angle=90]{@@1@@.pdf}}\\[0.01cm]\hdashline\noalign{\vskip 0.1cm}
+	\rotatebox{90}{@@color2@@ @@2@@}\resizebox{13cm}{\height}{\includegraphics[angle=90]{@@2@@.pdf}}\\[0.01cm]\hdashline\noalign{\vskip 0.1cm}
+	\rotatebox{90}{@@color3@@ @@3@@}\resizebox{13cm}{\height}{\includegraphics[angle=90]{@@3@@.pdf}}\\[0.01cm]\hdashline\noalign{\vskip 0.1cm}
+	\rotatebox{90}{@@color4@@ @@4@@}\resizebox{13cm}{\height}{\includegraphics[angle=90]{@@4@@.pdf}}\\[0.01cm]\hdashline\noalign{\vskip 0.1cm}
+	\rotatebox{90}{@@color5@@ @@5@@}\resizebox{13cm}{\height}{\includegraphics[angle=90]{@@5@@.pdf}}\\[0.01cm]\hdashline\noalign{\vskip 0.1cm}
+	\rotatebox{90}{@@color6@@ @@6@@}\resizebox{13cm}{\height}{\includegraphics[angle=90]{@@6@@.pdf}}\\[0.01cm]\hdashline\noalign{\vskip 0.1cm}
+	\rotatebox{90}{@@color7@@ @@7@@}\resizebox{13cm}{\height}{\includegraphics[angle=90]{@@7@@.pdf}}\\[0.01cm]\hdashline\noalign{\vskip 0.1cm}
+	\rotatebox{90}{@@color8@@ @@8@@}\resizebox{13cm}{\height}{\includegraphics[angle=90]{@@8@@.pdf}}\\[0.01cm]\hdashline\noalign{\vskip 0.1cm}
+	\rotatebox{90}{@@color9@@ @@9@@}\resizebox{13cm}{\height}{\includegraphics[angle=90]{@@9@@.pdf}}\\[0.01cm]\hdashline\noalign{\vskip 0.1cm}
+	\rotatebox{90}{@@color10@@ @@10@@}\resizebox{13cm}{\height}{\includegraphics[angle=90]{@@10@@.pdf}}\\[0.01cm]\hdashline\noalign{\vskip 0.1cm}
+	\rotatebox{90}{@@color11@@ @@11@@}\resizebox{13cm}{\height}{\includegraphics[angle=90]{@@11@@}}\\[0.01cm]\hdashline\noalign{\vskip 0.1cm}
+	\rotatebox{90}{@@color12@@ @@12@@}\resizebox{13cm}{\height}{\includegraphics[angle=90]{@@12@@}}\\[0.01cm]\hdashline\noalign{\vskip 0.1cm}
+	\rotatebox{90}{@@color13@@ @@13@@}\resizebox{13cm}{\height}{\includegraphics[angle=90]{@@13@@}}
+\end{tabular}
+\end{minipage}
+\begin{minipage}[t]{5cm}
+\begin{tabular}{c:c:c}
+  @@color14@@ @@14@@ & @@color15@@ @@15@@ & @@color16@@ @@16@@ \\
+	\resizebox{\width}{13cm}{\includegraphics{@@14@@.pdf}} &
+	\resizebox{\width}{13cm}{\includegraphics{@@15@@.pdf}} &
+	\resizebox{\width}{13cm}{\includegraphics{@@16@@.pdf}}\\[0.01cm]\hdashline\noalign{\vskip 0.1cm}
+  @@color17@@ @@17@@ & @@color18@@ @@18@@ & @@color19@@ @@19@@ \\
+	\resizebox{\width}{13cm}{\includegraphics{@@17@@.pdf}} &
+	\resizebox{\width}{13cm}{\includegraphics{@@18@@.pdf}} &
+	\resizebox{\width}{13cm}{\includegraphics{@@19@@.pdf}}
+\end{tabular}
+\end{minipage}
+\newpage

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1234,9 +1234,9 @@ They consist of the following elements:
 
 \paragraph{Barcodes.}
 All bases are labeled with a horizontally encircling, white glossy tag
-covering about 50 percent of the bases height (from the center)
 containing a white reference area as well as an identifying
-barcode. Each base is equipped with a unique ID\@. \reffig{fig:barcode}
+UPC-E barcode.
+Each base is equipped with a unique ID\@. \reffig{fig:barcode}
 shows a prototype of a barcode labeled workpiece.
 
 The barcodes can be scanned at each station via attached barcode scanners and


### PR DESCRIPTION
The rulebook does not mention the barcode format yet. The barcodes we have on our workpieces are from the UPC-E standard. Assuming those are the correct ones, we should state that in the rulebook. Can anyone confirm this?