### PR TITLE
Add clarification to machine broken time

### DIFF
--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1526,16 +1526,17 @@ This causes the \ac{MPS} to go into the broken state as well.
 \label{sec:broken-machine}
 If a machine is improperly instructed or used, or a reset message has
 been sent, the machine will go into a failure state. The machine cannot be
-used for 30 seconds and until repaired.
+used for 30 seconds and until repaired. This includes interactions with shelves,
+conveyor belts, or slides.
 That is, if damage was
 inflicted on the machine or the referee needs longer to repair the
 machine the game continues and the machine will be offline for a
 longer time. Any production that was running will be aborted and any
-product which was being processed is no longer available and will be
-removed by the referee. Any additional bases or caps buffered at the machine
-will be void and the points gained removed. For storage stations, no
-slot is refilled, the load status remains exactly as before the broken
-state. The downtime is indicated by a flashing red light.
+product which was being processed or placed into the machine's input or output
+is no longer available and will be removed by the referee. Any additional bases
+or caps buffered at the machine will be void and the points gained removed.
+For storage stations, no slot is refilled, the load status remains exactly as
+before the broken state. The downtime is indicated by a flashing red light.
 
 
 \subsubsection{Scheduled Machine Downtime}


### PR DESCRIPTION
The description of machine downtime interactions and workpiece handling left room for interpretation, as noted in #34. This change reflects how things are effectively handled during real RCLL tournaments and clarifies related rules.