### PR TITLE
Rework of delivery in challenges

### DIFF
--- a/rulebook.tex
+++ b/rulebook.tex
@@ -2581,10 +2581,10 @@ be executed following the regular rules for the \ac{RCLL}.
 However, some aspects are altered to simplify the setup.
 
 \paragraph{Product Delivery}
-It is possible to deliver a Product to the delivery station. To reduce the
-amount of machines required for participation, it is also possible to bring
-the finished product to the insertion area and drop it there. A team has to
-specify the type of delivery before the challenge starts.
+To reduce the amount of machines required for participation, it is possible to bring
+the finished product to the insertion area and drop it there, instead of bringing it
+to a delivery station. A team has to specify the type of delivery before the
+challenge starts.
 
 \paragraph{Ring Color Assignment}
 The cost for mounting each ring color are fixed, the assignment of ring colors

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -2581,10 +2581,10 @@ be executed following the regular rules for the \ac{RCLL}.
 However, some aspects are altered to simplify the setup.
 
 \paragraph{Product Delivery}
-To reduce the amount of machines required for participation, it is possible to bring
-the finished product to the insertion area and drop it there, instead of bringing it
-to a delivery station. A team has to specify the type of delivery before the
-challenge starts.
+To reduce the amount of machines required for participation, it is possible to
+bring the finished product to the insertion area and drop it there, instead of
+bringing it to a delivery station. A team has to specify the type of delivery
+before the challenge starts.
 
 \paragraph{Ring Color Assignment}
 The cost for mounting each ring color are fixed, the assignment of ring colors

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -2523,10 +2523,10 @@ be executed following the regular rules for the \ac{RCLL}.
 However, some aspects are altered to simplify the setup.
 
 \paragraph{Product Delivery}
-The delivery procedure for finished products is altered compared to the
-\ac{RCLL} rule set. In order to reduce the amount of machines required
-for participation, deliveries are made by bringing the finished product
-to the insertion area and dropping it there.
+It is possible to deliver a Product to the delivery station. To reduce the
+amount of machines required for participation, it is also possible to bring
+the finished product to the insertion area and drop it there. A team has to
+specify the type of delivery before the challenge starts.
 
 \paragraph{Ring Color Assignment}
 The cost for mounting each ring color are fixed, the assignment of ring colors


### PR DESCRIPTION
This PR rewrites the delivery rules in challenge games. As stated in #76 it is now also allowed to do the delivery to a delivery station. The old rule with dropping it in the starting zone is still there to reduce the amount of machines needed. But a team has to specify in advance which type of delivery it will be doing. 