### PR TITLE
Potentially allow other wireless communication methods

### DIFF
--- a/rulebook.tex
+++ b/rulebook.tex
@@ -2049,8 +2049,12 @@ box (cf.~\refsec{sec:referee-box}).
 
 Robots have to operate autonomously, that is, without any human
 interference during the game. Communication among robots and to
-off-board computing units is allowed only using wifi
-(cf.~\refsec{sec:wifi-regulations}). Communication is not guaranteed
+off-board computing units is in principle only allowed using wifi
+(cf.~\refsec{sec:wifi-regulations}). If the event regulations set by the
+venue organizers, organizing committee and technical committee allow it, other
+wireless communication methods (e.g., broadband cellular) might be used after
+explicit approval is granted.
+Communication is not guaranteed
 and may be unavailable during parts of the game. Interruptions must be
 expected and are no reason to pause or abort a game, even if they
 endure for long periods of the game.


### PR DESCRIPTION
In RoboCup 2022, team Carologistics used cellular data for communication after explicit approval from the other teams. This is now codified, addressing #78.