### PR TITLE
Rework scoring on delivery

### DIFF
--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1719,12 +1719,6 @@ The scoring is shown in \reftab{tab:scoring}.
         & Finish the work order for a color requiring two additional bases
         & $+20$
         \\
-        Finish $C_1$ pre-cap & Mount the last ring of a $C_1$ product & $+10$
-        \\
-        Finish $C_2$ pre-cap & Mount the last ring of a $C_2$ product & $+30$
-        \\
-        Finish $C_3$ pre-cap & Mount the last ring of a $C_3$ product & $+80$
-        \\
         Mount cap & Mount the cap on a product & $+10$
         \\
         Retrieve cap & Buffer a cap into a cap station & $+2$
@@ -1737,9 +1731,9 @@ The scoring is shown in \reftab{tab:scoring}.
         & A workpiece is stored into the \ac{SS}
         & $-5$
         \\
-        Delivery
-        & Deliver one of the final product variants to the designated loading
-        zone at the time specified in the order
+        Delivery C0
+        & Deliver a product of complexity C0 to the designated loading
+        zone
         & $+20$
         \\
         Delayed Delivery & An order delivered within 10 seconds after an order
@@ -1747,6 +1741,21 @@ The scoring is shown in \reftab{tab:scoring}.
         delivery time $T_d$ in seconds the reduced score is given by \newline
         $\lfloor 15 - \lfloor T_d - T_e \rfloor * 1.5 + 5 \rfloor$
         & up to $+20$
+        \\
+        Delivery C1
+        & Deliver a product of complexity C1 to the designated loading
+        zone
+        & $+30$
+        \\
+        Delivery C2
+        & Deliver a product of complexity C2 to the designated loading
+        zone
+        & $+50$
+        \\
+        Delivery C3
+        & Deliver a product of complexity C3 to the designated loading
+        zone
+        & $+100$
         \\
         Late Delivery & An order delivered after 10 seconds & +5 \\
         Wrong delivery & Deliver one of the final product variants to

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1454,7 +1454,8 @@ the cap is mounted.
 The \ac{DS} prepare message denotes the order ID of the product
 that is delivered.
 The \ac{DS} will consume any workpiece provided,
-but points can only be scored if the \ac{DS} has been properly prepared.
+but points can only be scored if the delivered workpiece fulfills the
+requirements of the provided order ID (see \reftab{tab:scoring}).
 
 \noindent\textbf{\acl{SS}}
 The \ac{SS} prepare message denotes the storage place (shelf and slot number)

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1736,12 +1736,6 @@ The scoring is shown in \reftab{tab:scoring}.
         zone
         & $+20$
         \\
-        Delayed Delivery & An order delivered within 10 seconds after an order
-        is awarded a reduced score. For delivery time slot end $T_e$ and actual
-        delivery time $T_d$ in seconds the reduced score is given by \newline
-        $\lfloor 15 - \lfloor T_d - T_e \rfloor * 1.5 + 5 \rfloor$
-        & up to $+20$
-        \\
         Delivery C1
         & Deliver a product of complexity C1 to the designated loading
         zone
@@ -1757,14 +1751,26 @@ The scoring is shown in \reftab{tab:scoring}.
         zone
         & $+100$
         \\
-        Late Delivery & An order delivered after 10 seconds & +5 \\
-        Wrong delivery & Deliver one of the final product variants to
-        the designated loading zone out of the requested time range or
-        after all products requested in the period have already been
-        delivered
-        & $+1$
+        Delayed Delivery & An order delivered after its delivery deadline is
+        penalized. The penalty is a fraction of the points $P_d$
+        scored upon delivery and it depends on the actual
+        delivery time $T_d$ and the delivery window $[T_s, T_e]$.
+        Starting with a penalty of 15\%, it increases by the same amount for
+        every $\frac{T_e-T_s}{5}$ seconds passed since
+        the delivery window end $T_e$ up to the actual delivery time $T_d$.
+        However, the penalty is capped at a maximum of $- 75\%$ of $P_d$.
+        &
+        $-15\%\cdot P_d$
+        $-30\%\cdot P_d$
+        $-45\%\cdot P_d$
+        $-60\%\cdot P_d$
+        $-75\%\cdot P_d$
+        \phantom{$-75\%\cdot P_d$} % prevent weird latex formatting issue
         \\
-        False delivery & Deliver an intermediate product & $0$
+        Wrong delivery & Deliver one of the final product variants after all
+        products requested have already been delivered or deliver a unrequested
+        or unfinished product
+        & $0$
         \\
         1st competitive delivery
         & Points for the first delivery for a competitive order. The score is

--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1456,6 +1456,9 @@ that is delivered.
 The \ac{DS} will consume any workpiece provided,
 but points can only be scored if the delivered workpiece fulfills the
 requirements of the provided order ID (see \reftab{tab:scoring}).
+If the delivery window of the supplied order ID has not started yet, then the
+machine will wait until the delivery start time is crossed before processing
+the consumption.
 
 \noindent\textbf{\acl{SS}}
 The \ac{SS} prepare message denotes the storage place (shelf and slot number)


### PR DESCRIPTION
This PR introduces a few rule changes around the scoring and handling of early, normal and late deliveries.
The technical implementation is handled in https://github.com/robocup-logistics/rcll-refbox/pull/146.

1. The point scoring for mounting the last ring of a product is moved to become part of the regular delivery points. This does change the total points that orders achieve, it just simplifies the handling by treating scoring of ring payments equal independent to the order they belong to.
2. With the above change the amount of delivery points now varies depending on the complexity and allows us to punish the late delivery of workpieces more harshly (up to 75% of the delivery points, which is up to 75 points for a C3 product). Additionally, the gradual point deduction is spread over a larger time span (based on the length of the original delivery window). 
  The old rules only deducted up to 15 points, which in the grand scheme of things is not really significant in many situations (especially with complex orders that yield around 150 points on delivery).  The time span between receiving full points at the end of the delivery window and receiving minimal points for late deliveries was only a few seconds.
3. Treat wrong deliveries equally, whether a wrong product was build or a product was delivered more often than requested.
  (Previously, a duplicate delivery was awarded with 1 point.)
4. Do not treat early deliveries as errors (in a sense that they end up scoring 0 points), but rather make them block the delivery station until the delivery window starts.
