### PR TITLE
Clarify rules for remote challenges and specify documents for submission

### DIFF
--- a/rulebook.tex
+++ b/rulebook.tex
@@ -2448,20 +2448,24 @@ competition area for a match.
 Up to four \ac{MPS} may be placed on a field, depending on the chosen challenge.
 
 \subsubsection{Remote Setup}
-In case a competition is carried out remotely, a proper local setup has to
-be established and approved by the \ac{OC}.
-Requirements include a proper camera setup that covers the field sufficiently,
-such that external viewers can verify the integrity of each challenges,
+In case a competition is carried out remotely, a rule-compliant local setup
+has to be established.
+Requirements include a camera setup that covers the field sufficiently
+such that external viewers can verify the integrity of each of the challenges,
+a screen recording of the corresponding refbox frontend,
 as well as an approval for every mockup machine and robot that is used.
 To ease the setup, rules regarding required wall segments at the field borders
 are suspended in remote competitions.
+When challenges are played remotely, a recording of each run (which includes
+the logs from the refbox, the video of the field and the screenrecording of
+the refbox frontend) must be submitted to the \ac{OC}. The video proof should
+be sufficient in quality such that general game integrity can be verified.
 
 After registration the \ac{OC} will verify the field setup in a video call.
 The validation call will be scheduled individually for each team
-to account for timezones.
+to account for timezones. Remote participation is only allowed after the setup
+has been approved and only with the approved setup.
 
-When challenges are played remotely, a video recording of the live-streams
-hast to be sent to the \ac{OC}.
 
 
 \subsubsection{Overview --- Challenge Track}


### PR DESCRIPTION
#77 mentions underspecification of the materials to hand-in in remote competitions. This suggested change adds details to the required materials based on the practical implementation of the rules in 2021.  