### PR TITLE
Clarify responsibility of replenishers for clearing slides

### DIFF
--- a/rulebook.tex
+++ b/rulebook.tex
@@ -1945,6 +1945,8 @@ enter the competition-area without asking the referee. Shelves have to be
 (re-)filled in all three reachable slots. % chktex 36
 The replenisher may restock only caps if transparent base elements have been put
 back to the shelf, once no cap is remaining on this shelf.
+Ring station slides must be emptied once three payments are inserted to avoid
+overflowing slides.
 
 The teams are partly free to choose their assembly and placement of products.
 For example, teams can fill any number of bases into a \ac{BS} or are free


### PR DESCRIPTION
During the last RoboCup event it occured that RS slides weren't emptied on time leading to overflow and a machine entering the broken state. To clarify responsibility, this rule change specifies that the replenishers are responsible for clearing the slides once three payments have been inserted.