### PR TITLE
rulebook: switch to non-kbsg mailing lists

### DIFF
--- a/rulebook.tex
+++ b/rulebook.tex
@@ -454,7 +454,7 @@ Biel, Switzerland\\
 
 \medskip
 \noindent To get into contact with the \ac{TC} use the mailing list\\
-\centerline{\url{robocup-logistics-tc@lists.kbsg.rwth-aachen.de}}
+\centerline{\url{robocup-logistics-tc@lists.rwth-aachen.de}}
 
 \subsection{Organizing Committee 2022}
 \label{sec:oc}
@@ -470,7 +470,7 @@ Mittelland, Biel, Switzerland\\
 
 \medskip
 \noindent To get into contact with the \ac{OC} use the mailing list\\
-\centerline{\url{robocup-logistics-oc@lists.kbsg.rwth-aachen.de}}
+\centerline{\url{robocup-logistics-oc@lists.rwth-aachen.de}}
 
 \subsection{Executive Committee}
 \label{sec:ec}
@@ -494,7 +494,7 @@ The website of the RoboCup Logistics League is available at\\
 \noindent
 A mailing list for general announcements and discussion about the
 league is available at\\
-\centerline{\url{https://lists.kbsg.rwth-aachen.de/listinfo/robocup-logistics}}
+\centerline{\url{https://lists.rwth-aachen.de/listinfo/robocup-logistics}}
 
 \smallskip
 \noindent


### PR DESCRIPTION
The KBSG no longer hosts mailing lists.