### PR TITLE
update description of challenge field to refbox changes

### DIFF
--- a/rulebook.tex
+++ b/rulebook.tex
@@ -587,13 +587,11 @@ An example of a competition area with aspect ratio 1 is shown in
 it spans a \SI{5 x 5}{\metre} large %chktex 29
 arena with 25 square zones, where 3 machines are placed.
 
-Only one team at a time competes on the area, the chosen team-color
-does not matter. However, the field coordinates resemble the magenta halve
-of the field, hence the coordinates on the x-axis of all zones are negative.
-Teams can play as either cyan or magenta, as machine positions published by
-the \ac{refbox} place the machines of both teams on the same location
-(e.g., M-BS and C-BS are both placed at M-Z12 in the field of
-\reffig{fig:competition-area-challenges}).
+Only one team at a time competes on the area, the team can play as either
+cyan or magenta.
+The refbox publishes machine infos for both cyan and magenta, e.g., in
+the field of \reffig{fig:competition-area-challenges} a team playing as magenta
+places M-BS in M-Z12, while a team playing as cyan places C-BS at C-Z12.
 
 \begin{figure}[!ht]
     \includegraphics{challenge-field2021.pdf}


### PR DESCRIPTION
This change is implemented through https://github.com/robocup-logistics/rcll-refbox/pull/196.

Originally, the challange track fields were played on magenta-halve, because the refbox generated fields on magenta and mirrored them to cyan.
Machines for both teams were placed on top of eachother, so team cyan could play on the magenta halve.

There were 2 issues with this:
1. The field generation constraints were actually for team cyan and interpreted as team magenta machines causing errors regarding legal rotations for delivery stations.
2. Some participants prefer to not receive machine info for machines that are placed on top of eachother.

To address this, actually treat the generated field correctly as cyan field, mirror it to magenta regardless and therefore let teams divide whether to play as cyan in the cyan half or as magenta in the magenta half.
